### PR TITLE
fix: changed ResultCode and ResponseCode to have int | str type due t…

### DIFF
--- a/mpesa_sdk/C2B/schemas.py
+++ b/mpesa_sdk/C2B/schemas.py
@@ -181,7 +181,7 @@ class C2BValidationRequest(BaseModel):
 class C2BValidationResponse(BaseModel):
     """Schema for response to validation requests (accept/reject payment)."""
 
-    ResultCode: str = Field(..., description="0 to accept, error code to reject.")
+    ResultCode: int | str = Field(..., description="0 to accept, error code to reject.")
     ResultDesc: str = Field(..., description="Short description: Accepted or Rejected.")
     ThirdPartyTransID: Optional[str] = Field(
         None, description="Optional partner transaction ID."

--- a/mpesa_sdk/business_paybill/schemas.py
+++ b/mpesa_sdk/business_paybill/schemas.py
@@ -111,7 +111,7 @@ class BusinessPayBillResultMetadata(BaseModel):
     """Metadata for Business PayBill result notification."""
 
     ResultType: int = Field(..., description="Type of result (0=Success, 1=Failure).")
-    ResultCode: int = Field(..., description="Result code (0=Success).")
+    ResultCode: int | str = Field(..., description="Result code (0=Success).")
     ResultDesc: str = Field(..., description="Result description.")
     OriginatorConversationID: str = Field(
         ..., description="Originator conversation ID."

--- a/mpesa_sdk/tax_remittance/schemas.py
+++ b/mpesa_sdk/tax_remittance/schemas.py
@@ -54,7 +54,7 @@ class TaxRemittanceResponse(BaseModel):
     ConversationID: Optional[str] = Field(
         ..., description="Unique ID for the transaction."
     )
-    ResponseCode: str = Field(..., description="Status code, 0 means success.")
+    ResponseCode: str | int = Field(..., description="Status code, 0 means success.")
     ResponseDescription: str = Field(..., description="Status message.")
 
     model_config = ConfigDict(
@@ -108,7 +108,7 @@ class TaxRemittanceResultMetadata(BaseModel):
     """Metadata for Tax Remittance result notification."""
 
     ResultType: int = Field(..., description="Type of result (0=Success, 1=Failure).")
-    ResultCode: int = Field(..., description="Result code (0=Success).")
+    ResultCode: int | str = Field(..., description="Result code (0=Success).")
     ResultDesc: str = Field(..., description="Result description.")
     OriginatorConversationID: str = Field(
         ..., description="Originator conversation ID."
@@ -192,7 +192,8 @@ class TaxRemittanceResultCallback(BaseModel):
 
     def is_successful(self) -> bool:
         """Check if the result indicates success."""
-        return self.Result.ResultCode == 0
+        code = str(self.Result.ResultCode)
+        return code.strip("0") == "" and code != ""
 
 
 class TaxRemittanceResultCallbackResponse(BaseModel):


### PR DESCRIPTION
<!-- 
  Thanks for contributing to the project! Please fill out this template so we can review your PR effectively.
  Delete any sections that aren't applicable.
-->

## Description

<!-- 
  Describe the changes introduced by this PR. Include context, motivation, and what problem this solves.
  If this fixes an issue, link it here with "Fixes #123".
-->

- In Mpesa Daraja API there is always a mismatch in the Result and Response Code being either `str` or `int`. I've refactored for the response schemas to support this.

## Type of Change

<!-- Check one or more of the following options, and delete the others. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation update
- [ ] Refactor (code structure improvements, no new functionality)
- [ ] Tests (addition or improvement of tests)
- [ ] Chore (changes to tooling, CI/CD, or metadata)

## How Has This Been Tested?

<!-- 
  Describe how you tested your changes (unit tests, integration tests, manual testing, etc.).
  Include any relevant details such as test environments or edge cases considered.
-->

## Checklist

<!-- 
  Go over all the following points, and put an `x` in all the boxes that apply.
  If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<!-- 
  Add screenshots to show UI changes or before/after comparisons.
  You can drag and drop images directly into the PR on GitHub.
-->

## Additional Context

<!-- 
  Add any other context about the PR here (e.g., performance implications, future work, etc.).
-->