### PR TITLE
FEAT: Migrate Pydantic model serialization from dict() to model_dump(…

### DIFF
--- a/mpesakit/account_balance/account_balance.py
+++ b/mpesakit/account_balance/account_balance.py
@@ -43,5 +43,5 @@ class AccountBalance(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return AccountBalanceResponse(**response_data)

--- a/mpesakit/b2c/b2c.py
+++ b/mpesakit/b2c/b2c.py
@@ -43,5 +43,5 @@ class B2C(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return B2CResponse(**response_data)

--- a/mpesakit/business_buy_goods/business_buy_goods.py
+++ b/mpesakit/business_buy_goods/business_buy_goods.py
@@ -43,5 +43,5 @@ class BusinessBuyGoods(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return BusinessBuyGoodsResponse(**response_data)

--- a/mpesakit/business_paybill/business_paybill.py
+++ b/mpesakit/business_paybill/business_paybill.py
@@ -43,5 +43,5 @@ class BusinessPayBill(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return BusinessPayBillResponse(**response_data)

--- a/mpesakit/c2b/c2b.py
+++ b/mpesakit/c2b/c2b.py
@@ -41,7 +41,7 @@ class C2B(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
 
         # Safaricom API Bug: There is a typo in the response field name
         # "OriginatorCoversationID" should be "OriginatorConversationID"

--- a/mpesakit/dynamic_qr_code/dynamic_qr_code.py
+++ b/mpesakit/dynamic_qr_code/dynamic_qr_code.py
@@ -44,6 +44,6 @@ class DynamicQRCode(BaseModel):
             "Content-Type": "application/json",
         }
 
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
 
         return DynamicQRGenerateResponse(**response_data)

--- a/mpesakit/mpesa_express/stk_push.py
+++ b/mpesakit/mpesa_express/stk_push.py
@@ -43,7 +43,7 @@ class StkPush(BaseModel):
             "Content-Type": "application/json",
         }
 
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
 
         return StkPushSimulateResponse(**response_data)
 

--- a/mpesakit/reversal/reversal.py
+++ b/mpesakit/reversal/reversal.py
@@ -44,5 +44,5 @@ class Reversal(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return ReversalResponse(**response_data)

--- a/mpesakit/tax_remittance/tax_remittance.py
+++ b/mpesakit/tax_remittance/tax_remittance.py
@@ -43,5 +43,5 @@ class TaxRemittance(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return TaxRemittanceResponse(**response_data)

--- a/mpesakit/transaction_status/transaction_status.py
+++ b/mpesakit/transaction_status/transaction_status.py
@@ -43,5 +43,5 @@ class TransactionStatus(BaseModel):
             "Authorization": f"Bearer {self.token_manager.get_token()}",
             "Content-Type": "application/json",
         }
-        response_data = self.http_client.post(url, json=dict(request), headers=headers)
+        response_data = self.http_client.post(url, json=request.model_dump(by_alias=True), headers=headers)
         return TransactionStatusResponse(**response_data)


### PR DESCRIPTION


## Description

This Pull Request updates the codebase for **Pydantic V2 compatibility** by migrating model serialization calls.

Specifically, it replaces instances of:
1.  `dict(request_model)` with **`request_model.model_dump(by_alias=True)`** in client methods.
2.  `model.dict()` (if used directly) with **`model.model_dump(by_alias=True)`**.

This change is necessary because Pydantic V2 deprecated direct iteration for serialization, and `model_dump()` is the correct method for generating JSON-compatible Python dictionaries, while preserving the API-required aliases (e.g., `PartyA`, `QueueTimeOutURL`).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation update
- [x] Refactor (code structure improvements, no new functionality)
- [ ] Tests (addition or improvement of tests)
- [x] Chore (changes to tooling, CI/CD, or metadata)

---

## How Has This Been Tested?

1.  **Unit Tests:** All existing unit tests were run and passed successfully, confirming that the change in serialization method did not alter the data sent to the HTTP client mock.
2.  **Integration Test (Manual/Sandbox):** A manual request (e.g., an `AccountBalance.query()`) was executed against the M-Pesa sandbox environment to confirm the payload is correctly constructed and the API responds as expected.

---

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas *(The change is standard Pydantic V2 migration; no new complex logic was added.)*
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works *(Relying on existing tests, as the serialization output should remain identical.)*
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

## Screenshots (if applicable)

N/A

---

## Additional Context

This migration is a necessary step towards fully supporting Pydantic V2 and removes potential deprecation warnings that would appear when running under a V2 environment. The `by_alias=True` is critical to maintain compatibility with the M-Pesa API's camel-cased fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated request payload serialization across all M-Pesa API endpoints (Account Balance, B2C Payment, Business Buy Goods, Business Paybill, C2B, Dynamic QR Code, STK Push, Reversal, Tax Remittance, and Transaction Status) to ensure consistent and proper field naming in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->