### PR TITLE
Fix broken discord link

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -122,7 +122,7 @@ const config: Config = {
             },
             // {
             //   label: 'Discord',
-            //   href: 'https://discord.gg/docusaurus', // Optional: create your own
+            //   href: 'https://discord.gg/hNxTew523E', // Optional: create your own
             // },
             // {
             //   label: 'Stack Overflow',


### PR DESCRIPTION
Updated the Discord link to the new link provided by the project owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Discord invite link used in the site navigation to the new invite.
  * Synchronized the same Discord invite reference in the footer comment to match the navigation.
  * No functional behavior changes; this is a documentation/link update to ensure users reach the correct community invite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->