### PR TITLE
A followup to pr #127

### DIFF
--- a/tests/unit/mpesa_express/test_stk_push.py
+++ b/tests/unit/mpesa_express/test_stk_push.py
@@ -211,13 +211,13 @@ def test_stk_push_simulation_session_behavior(use_session, mock_token_manager):
         assert client._client is None
         with patch("mpesakit.http_client.mpesa_http_client.httpx.Client.post", return_value=httpx.Response(200, json=response_data)) as mock_post:
             success_count = 0
-            for _ in range(98):
+            for _ in range(100):
                 response = stk_push.push(request)
                 if response.is_successful():
                     success_count += 1
 
-            assert success_count == 98
-            assert mock_post.call_count == 98
+            assert success_count == 100
+            assert mock_post.call_count == 100
 
     if client._client is not None:
         client.close()
@@ -369,11 +369,11 @@ async def test_async_stk_push_simulation_repeated_calls(async_stk_push, mock_asy
     mock_async_http_client.post.return_value = response_data
 
     success_count = 0
-    for _ in range(99):
+    for _ in range(100):
         response = await async_stk_push.push(request)
         if response.is_successful():
             success_count += 1
 
-    assert success_count == 99
-    assert mock_async_http_client.post.call_count == 99
+    assert success_count == 100
+    assert mock_async_http_client.post.call_count == 100
 

--- a/tests/unit/mpesa_express/test_stk_push.py
+++ b/tests/unit/mpesa_express/test_stk_push.py
@@ -40,23 +40,6 @@ def stk_push(mock_http_client, mock_token_manager):
     """Fixture to create an instance of StkPush with mocked dependencies."""
     return StkPush(http_client=mock_http_client, token_manager=mock_token_manager)
 
-
-def build_stk_push_simulate_request():
-    return StkPushSimulateRequest(
-        BusinessShortCode=174379,
-        Password="test_password",
-        Timestamp="20220101010101",
-        TransactionType="CustomerPayBillOnline",
-        Amount=10,
-        PartyA="254700000000",
-        PartyB="174379",
-        PhoneNumber="254700000000",
-        CallBackURL="https://test.com/callback",
-        AccountReference="TestAccount",
-        TransactionDesc="Test Payment",
-    )
-
-
 def test_push_success(stk_push, mock_http_client):
     """Test that a successful STK Push transaction can be initiated."""
     request = StkPushSimulateRequest(
@@ -182,7 +165,20 @@ def test_stk_push_simulate_request_invalid_transaction_type():
 @pytest.mark.parametrize("use_session", [True, False])
 def test_stk_push_simulation_session_behavior(use_session, mock_token_manager):
     """Test repeated STK Push simulation with and without the sync HTTP client session."""
-    request = build_stk_push_simulate_request()
+    request = StkPushSimulateRequest(
+        BusinessShortCode=174379,
+        Password="test_password",
+        Timestamp="20220101010101",
+        TransactionType="CustomerPayBillOnline",
+        Amount=10,
+        PartyA="254700000000",
+        PartyB="174379",
+        PhoneNumber="254700000000",
+        CallBackURL="https://test.com/callback",
+        AccountReference="TestAccount",
+        TransactionDesc="Test Payment",
+    )
+
     response_data = {
         "MerchantRequestID": "12345",
         "CheckoutRequestID": "ws_CO_260520211133524545",
@@ -355,7 +351,20 @@ async def test_async_query_handles_http_error(async_stk_push, mock_async_http_cl
 @pytest.mark.asyncio
 async def test_async_stk_push_simulation_repeated_calls(async_stk_push, mock_async_http_client):
     """Test repeated async STK Push simulation calls with the async client."""
-    request = build_stk_push_simulate_request()
+    request = StkPushSimulateRequest(
+        BusinessShortCode=174379,
+        Password="test_password",
+        Timestamp="20220101010101",
+        TransactionType="CustomerPayBillOnline",
+        Amount=10,
+        PartyA="254700000000",
+        PartyB="174379",
+        PhoneNumber="254700000000",
+        CallBackURL="https://test.com/callback",
+        AccountReference="TestAccount",
+        TransactionDesc="Test Payment",
+    )
+
     response_data = {
         "MerchantRequestID": "12345",
         "CheckoutRequestID": "ws_CO_260520211133524545",

--- a/tests/unit/mpesa_express/test_stk_push.py
+++ b/tests/unit/mpesa_express/test_stk_push.py
@@ -3,12 +3,14 @@
 This module tests the StkPush class for initiating and querying M-Pesa STK Push transactions.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.http_client import AsyncHttpClient, HttpClient
+from mpesakit.http_client.mpesa_http_client import MpesaHttpClient
 from mpesakit.mpesa_express.stk_push import (
     AsyncStkPush,
     StkPush,
@@ -37,6 +39,22 @@ def mock_http_client():
 def stk_push(mock_http_client, mock_token_manager):
     """Fixture to create an instance of StkPush with mocked dependencies."""
     return StkPush(http_client=mock_http_client, token_manager=mock_token_manager)
+
+
+def build_stk_push_simulate_request():
+    return StkPushSimulateRequest(
+        BusinessShortCode=174379,
+        Password="test_password",
+        Timestamp="20220101010101",
+        TransactionType="CustomerPayBillOnline",
+        Amount=10,
+        PartyA="254700000000",
+        PartyB="174379",
+        PhoneNumber="254700000000",
+        CallBackURL="https://test.com/callback",
+        AccountReference="TestAccount",
+        TransactionDesc="Test Payment",
+    )
 
 
 def test_push_success(stk_push, mock_http_client):
@@ -160,6 +178,49 @@ def test_stk_push_simulate_request_invalid_transaction_type():
         StkPushSimulateRequest(**valid_kwargs)
     assert "TransactionType must be one of:" in str(excinfo.value)
 
+
+@pytest.mark.parametrize("use_session", [True, False])
+def test_stk_push_simulation_session_behavior(use_session, mock_token_manager):
+    """Test repeated STK Push simulation with and without the sync HTTP client session."""
+    request = build_stk_push_simulate_request()
+    response_data = {
+        "MerchantRequestID": "12345",
+        "CheckoutRequestID": "ws_CO_260520211133524545",
+        "ResponseCode": 0,
+        "ResponseDescription": "Success",
+        "ResultCode": 0,
+        "ResultDesc": "The service request is processed successfully.",
+        "CustomerMessage": "Success.Request accepted for processing.",
+    }
+
+    client = MpesaHttpClient(env="sandbox", use_session=use_session)
+    stk_push = StkPush(http_client=client, token_manager=mock_token_manager)
+
+    if use_session:
+        assert client._client is not None
+        with patch.object(client._client, "post", return_value=httpx.Response(200, json=response_data)) as mock_post:
+            success_count = 0
+            for _ in range(100):
+                response = stk_push.push(request)
+                if response.is_successful():
+                    success_count += 1
+
+            assert success_count == 100
+            assert mock_post.call_count == 100
+    else:
+        assert client._client is None
+        with patch("mpesakit.http_client.mpesa_http_client.httpx.Client.post", return_value=httpx.Response(200, json=response_data)) as mock_post:
+            success_count = 0
+            for _ in range(98):
+                response = stk_push.push(request)
+                if response.is_successful():
+                    success_count += 1
+
+            assert success_count == 98
+            assert mock_post.call_count == 98
+
+    if client._client is not None:
+        client.close()
 
 @pytest.fixture
 def mock_async_token_manager():
@@ -290,3 +351,29 @@ async def test_async_query_handles_http_error(async_stk_push, mock_async_http_cl
     with pytest.raises(Exception) as excinfo:
         await async_stk_push.query(request)
     assert "HTTP error" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_async_stk_push_simulation_repeated_calls(async_stk_push, mock_async_http_client):
+    """Test repeated async STK Push simulation calls with the async client."""
+    request = build_stk_push_simulate_request()
+    response_data = {
+        "MerchantRequestID": "12345",
+        "CheckoutRequestID": "ws_CO_260520211133524545",
+        "ResponseCode": 0,
+        "ResponseDescription": "Success",
+        "ResultCode": 0,
+        "ResultDesc": "The service request is processed successfully.",
+        "CustomerMessage": "Success.Request accepted for processing.",
+    }
+
+    mock_async_http_client.post.return_value = response_data
+
+    success_count = 0
+    for _ in range(99):
+        response = await async_stk_push.push(request)
+        if response.is_successful():
+            success_count += 1
+
+    assert success_count == 99
+    assert mock_async_http_client.post.call_count == 99
+


### PR DESCRIPTION
## Description
This PR is a follow-up on PR #127.
It aligns the `MpesaAsyncHttpClient` with the synchronous client to support unified retry functionality using the `tenacity` logic.

**Key Changes:**
- Implemented `@retry` decorators in `MpesaAsyncHttpClient` matching the sync implementation.
- Solves issue #116: Added simulation for 100 STK pushes to verify performance and session handling.
- Refactored internal `_raw_post` and `_raw_get` methods to handle low-level exceptions.

## Type of Change
- [x] Refactor (aligned async retry logic with sync client)
- [x] Tests (added 100 STK push simulation and retry path tests)

## How Has This Been Tested?
- **Unit Tests:** All existing tests in `tests/unit/http_client/` pass.
- **Simulation:** Verified 100 successful STK pushes using a persistent `httpx.AsyncClient` session.

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotent POSTs support automatic retries with injected idempotency keys; GET/POST accept optional headers and configurable timeouts; responses returned as parsed JSON.
  * Centralized HTTP error and retry handling reused across clients.

* **Bug Fixes**
  * No retries for 4xx client errors; clearer, consolidated mapping of connection/timeout failures to explicit error results.

* **Tests**
  * Added stress tests for repeated STK Push; tests for idempotency persistence, retry limits, and updated error-message expectations.

* **Documentation**
  * Example payloads now use a placeholder for the generated password.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->