### PR TITLE
add test for async balance service.

### DIFF
--- a/tests/unit/account_balance/test_account_balance.py
+++ b/tests/unit/account_balance/test_account_balance.py
@@ -3,8 +3,6 @@
 This module tests the AccountBalance class and its methods for querying account balance.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from mpesakit.account_balance import (
@@ -16,23 +14,6 @@ from mpesakit.account_balance import (
     AccountBalanceTimeoutCallback,
     AsyncAccountBalance,
 )
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def account_balance(mock_http_client, mock_token_manager):
@@ -40,7 +21,6 @@ def account_balance(mock_http_client, mock_token_manager):
     return AccountBalance(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_account_balance_request():
     """Create a valid AccountBalanceRequest for testing."""
@@ -54,7 +34,6 @@ def valid_account_balance_request():
         QueueTimeOutURL="https://example.com/timeout",
         ResultURL="https://example.com/result",
     )
-
 
 def test_query_returns_acknowledgement(account_balance, mock_http_client):
     """Test that query returns only the acknowledgement response, not the account balance."""
@@ -84,7 +63,6 @@ def test_query_returns_acknowledgement(account_balance, mock_http_client):
     assert args[0] == "/mpesa/accountbalance/v1/query"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
     assert kwargs["headers"]["Content-Type"] == "application/json"
-
 
 def test_callback_result_parsing():
     """Test parsing of AccountBalanceResultCallback with actual account balance data."""
@@ -134,7 +112,6 @@ def test_callback_result_parsing():
     assert account_balance_param is not None
     assert "Working Account|KES|700000.00" in account_balance_param.Value
 
-
 def test_account_balance_request_identifier_type_validation():
     """Test that AccountBalanceRequest raises ValueError for invalid IdentifierType."""
     valid_data = dict(
@@ -156,7 +133,6 @@ def test_account_balance_request_identifier_type_validation():
     with pytest.raises(ValueError, match="IdentifierType must be one of"):
         AccountBalanceRequest(**invalid_data)
 
-
 def test_account_balance_request_remarks_length_validation():
     """Test that AccountBalanceRequest raises ValueError for remarks exceeding 100 chars."""
     long_remarks = "x" * 101
@@ -172,7 +148,6 @@ def test_account_balance_request_remarks_length_validation():
     )
     with pytest.raises(ValueError, match="Remarks must not exceed 100 characters."):
         AccountBalanceRequest(**data)
-
 
 def test_timeout_callback_parsing():
     """Test parsing of AccountBalanceTimeoutCallback."""
@@ -192,7 +167,6 @@ def test_timeout_callback_parsing():
     assert callback.Result.ResultDesc == "The service request timed out."
     assert callback.Result.OriginatorConversationID == "16917-22577599-3"
     assert callback.Result.ConversationID == "AG_20200206_00005e091a8ec6b9eac5"
-
 
 def test_query_handles_string_response_code(account_balance, mock_http_client):
     """Ensure that ResponseCode as a string does not raise TypeError when checking is_successful."""
@@ -222,28 +196,12 @@ def test_query_handles_string_response_code(account_balance, mock_http_client):
     assert response_fail.is_successful() is False
     assert response_fail.ResponseCode == "1"
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager for testing."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_async_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_account_balance(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncAccountBalance instance with mocked dependencies."""
     return AsyncAccountBalance(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_query_returns_acknowledgement(
@@ -273,9 +231,8 @@ async def test_async_query_returns_acknowledgement(
     mock_async_http_client.post.assert_awaited_once()
     args, kwargs = mock_async_http_client.post.await_args
     assert args[0] == "/mpesa/accountbalance/v1/query"
-    assert kwargs["headers"]["Authorization"] == "Bearer test_async_token"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_token"
     assert kwargs["headers"]["Content-Type"] == "application/json"
-
 
 @pytest.mark.asyncio
 async def test_async_query_handles_string_response_code(

--- a/tests/unit/auth/test_token_manager.py
+++ b/tests/unit/auth/test_token_manager.py
@@ -5,11 +5,9 @@ These tests cover token retrieval, caching, and error handling for both synchron
 
 import pytest
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock , AsyncMock , patch
-from mpesakit.http_client import HttpClient,AsyncHttpClient
+from unittest.mock import patch
 from mpesakit.auth import TokenManager , AsyncTokenManager
 from mpesakit.errors import MpesaApiException, MpesaError
-
 
 @pytest.fixture
 def valid_credentials():
@@ -19,7 +17,6 @@ def valid_credentials():
         "consumer_secret": "test_secret",
     }
 
-
 @pytest.fixture
 def invalid_credentials():
     """Provide invalid M-Pesa credentials for testing."""
@@ -27,20 +24,6 @@ def invalid_credentials():
         "consumer_key": "invalid_key",
         "consumer_secret": "invalid_secret",
     }
-
-
-@pytest.fixture
-def mock_http_client():
-    """Provide a MagicMock HttpClient for testing."""
-    client = MagicMock(spec=HttpClient)
-    return client
-
-@pytest.fixture
-def mock_async_http_client():
-    """Provide a AsyncMock AsyncHttpClient for testing."""
-    client = AsyncMock(spec=AsyncHttpClient)
-    return client
-
 
 def test_get_token_success(valid_credentials, mock_http_client):
     """Test that a valid token can be retrieved."""
@@ -55,7 +38,6 @@ def test_get_token_success(valid_credentials, mock_http_client):
     )
     token = tm.get_token()
     assert token == "mocked_token_1234567890"
-
 
 def test_token_caching(valid_credentials, mock_http_client):
     """Test that the token is cached and reused until it expires."""
@@ -72,7 +54,6 @@ def test_token_caching(valid_credentials, mock_http_client):
     token2 = tm.get_token()
     assert token1 == token2
 
-
 def test_force_refresh_token(valid_credentials, mock_http_client):
     """Test that forcing a token refresh retrieves a new token."""
     mock_http_client.get.side_effect = [
@@ -88,7 +69,6 @@ def test_force_refresh_token(valid_credentials, mock_http_client):
     token2 = tm.get_token(force_refresh=True)
     assert token1 == "token1"
     assert token2 == "token2"
-
 
 def test_invalid_credentials_raises(mock_http_client, invalid_credentials):
     """Test that invalid credentials raise an exception."""
@@ -111,7 +91,6 @@ def test_invalid_credentials_raises(mock_http_client, invalid_credentials):
         or excinfo.value.error.status_code == 403
     )
 
-
 def test_invalid_grant_type(valid_credentials, mock_http_client, monkeypatch):
     """Test that an invalid grant type raises an exception."""
     tm = TokenManager(
@@ -129,7 +108,6 @@ def test_invalid_grant_type(valid_credentials, mock_http_client, monkeypatch):
     with pytest.raises(MpesaApiException) as excinfo:
         tm.get_token(force_refresh=True)
     assert excinfo.value.error.status_code == 403
-
 
 def test_invalid_auth_type(valid_credentials, mock_http_client, monkeypatch):
     """Test that an invalid auth type raises an exception."""
@@ -149,7 +127,6 @@ def test_invalid_auth_type(valid_credentials, mock_http_client, monkeypatch):
     with pytest.raises(MpesaApiException) as excinfo:
         tm.get_token(force_refresh=True)
     assert excinfo.value.error.status_code == 403
-
 
 def test_mpesa_api_exception_with_empty_error_message(
     valid_credentials, mock_http_client, monkeypatch
@@ -177,7 +154,6 @@ def test_mpesa_api_exception_with_empty_error_message(
     assert err.error_code == "AUTH_INVALID_CREDENTIALS"
     assert "Invalid credentials" in err.error_message
     assert err.status_code == 400
-
 
 def test_token_missing_raises_exception(
     valid_credentials, mock_http_client, monkeypatch
@@ -216,7 +192,6 @@ async def test_async_get_token_success(valid_credentials, mock_async_http_client
     assert token == "mocked_async_token"
     mock_async_http_client.get.assert_called_once()
 
-
 @pytest.mark.asyncio
 async def test_async_token_caching(valid_credentials, mock_async_http_client):
     """Test that the token is cached and reused asynchronously."""
@@ -233,7 +208,6 @@ async def test_async_token_caching(valid_credentials, mock_async_http_client):
     token2 = await tm.get_token()
     assert token1 == token2
     mock_async_http_client.get.assert_called_once()
-
 
 @pytest.mark.asyncio
 async def test_async_force_refresh_token(valid_credentials, mock_async_http_client):
@@ -252,7 +226,6 @@ async def test_async_force_refresh_token(valid_credentials, mock_async_http_clie
     assert token1 == "async_token1"
     assert token2 == "async_token2"
     assert mock_async_http_client.get.call_count == 2
-
 
 @pytest.mark.asyncio
 @patch("mpesakit.auth.token_manager.datetime")
@@ -279,7 +252,6 @@ async def test_async_expired_token_refresh(mock_dt, valid_credentials, mock_asyn
     assert token == "refreshed_async_token"
     assert mock_async_http_client.get.call_count == 2
 
-
 @pytest.mark.asyncio
 async def test_async_invalid_credentials_raises_custom_error(valid_credentials, mock_async_http_client):
     """Test the specific async logic for empty 400 response being converted to a detailed MpesaApiException."""
@@ -304,7 +276,6 @@ async def test_async_invalid_credentials_raises_custom_error(valid_credentials, 
     assert "Invalid credentials" in err.error_message
     assert err.status_code == 400
 
-
 @pytest.mark.asyncio
 async def test_async_invalid_grant_type(valid_credentials, mock_async_http_client, monkeypatch):
     """Test that an invalid grant type raises an exception asynchronously."""
@@ -323,7 +294,6 @@ async def test_async_invalid_grant_type(valid_credentials, mock_async_http_clien
     with pytest.raises(MpesaApiException) as excinfo:
         await tm.get_token(force_refresh=True)
     assert excinfo.value.error.status_code == 403
-
 
 @pytest.mark.asyncio
 async def test_async_invalid_auth_type(valid_credentials, mock_async_http_client, monkeypatch):

--- a/tests/unit/b2b_express_checkout/test_b2b_express_checkout.py
+++ b/tests/unit/b2b_express_checkout/test_b2b_express_checkout.py
@@ -4,11 +4,8 @@ This module tests the B2B Express Checkout API client, ensuring it can handle US
 process responses correctly, and manage callback/error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.b2b_express_checkout import (
     AsyncB2BExpressCheckout,
     B2BExpressCallbackResponse,
@@ -17,22 +14,6 @@ from mpesakit.b2b_express_checkout import (
     B2BExpressCheckoutRequest,
     B2BExpressCheckoutResponse,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def b2b_express_checkout(mock_http_client, mock_token_manager):
@@ -40,7 +21,6 @@ def b2b_express_checkout(mock_http_client, mock_token_manager):
     return B2BExpressCheckout(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_b2b_express_checkout_request():
     """Create a valid B2BExpressCheckoutRequest for testing."""
@@ -53,7 +33,6 @@ def valid_b2b_express_checkout_request():
         partnerName="VendorName",
         RequestRefID="550e8400-e29b-41d4-a716-446655440000",
     )
-
 
 def test_ussd_push_acknowledged(b2b_express_checkout, mock_http_client):
     """Test that USSD push request is acknowledged, not finalized."""
@@ -71,7 +50,6 @@ def test_ussd_push_acknowledged(b2b_express_checkout, mock_http_client):
     assert response.code == response_data["code"]
     assert response.status == response_data["status"]
 
-
 def test_ussd_push_http_error(b2b_express_checkout, mock_http_client):
     """Test handling of HTTP errors during USSD push request."""
     request = valid_b2b_express_checkout_request()
@@ -79,7 +57,6 @@ def test_ussd_push_http_error(b2b_express_checkout, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         b2b_express_checkout.ussd_push(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_b2b_express_checkout_success_callback():
     """Test parsing of a successful B2B Express Checkout callback."""
@@ -99,7 +76,6 @@ def test_b2b_express_checkout_success_callback():
     assert callback.transactionId == "RDQ01NFT1Q"
     assert callback.amount == 71.0
 
-
 def test_b2b_express_checkout_fail_callback():
     """Test parsing of a failed B2B Express Checkout callback."""
     payload = {
@@ -115,13 +91,11 @@ def test_b2b_express_checkout_fail_callback():
     assert callback.amount == 71.0
     assert callback.paymentReference == "MAndbubry3hi"
 
-
 def test_b2b_express_callback_response():
     """Test the response schema for B2B Express Checkout callback."""
     resp = B2BExpressCallbackResponse()
     assert resp.ResultCode == 0
     assert "Callback received successfully" in resp.ResultDesc
-
 
 def test_b2b_express_callback_resultcode_as_string():
     """Ensure resultCode as a string doesn't cause comparison/type errors in is_successful()."""
@@ -137,28 +111,12 @@ def test_b2b_express_callback_resultcode_as_string():
     assert callback.resultCode == "0"
     assert callback.is_successful() is True
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "async_test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_b2b_express_checkout(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncB2BExpressCheckout instance with mocked dependencies."""
     return AsyncB2BExpressCheckout(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_ussd_push_acknowledged(
@@ -180,7 +138,6 @@ async def test_async_ussd_push_acknowledged(
     assert response.code == response_data["code"]
     assert response.status == response_data["status"]
 
-
 @pytest.mark.asyncio
 async def test_async_ussd_push_http_error(
     async_b2b_express_checkout, mock_async_http_client
@@ -192,7 +149,6 @@ async def test_async_ussd_push_http_error(
     with pytest.raises(Exception) as excinfo:
         await async_b2b_express_checkout.ussd_push(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_ussd_push_token_manager_called(

--- a/tests/unit/b2c/test_b2c.py
+++ b/tests/unit/b2c/test_b2c.py
@@ -1,10 +1,7 @@
 """Unit tests for the B2C functionality of the Mpesa SDK."""
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.b2c import (
     B2C,
     AsyncB2C,
@@ -15,28 +12,11 @@ from mpesakit.b2c import (
     B2CResultMetadata,
     B2CResultParameter,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def b2c(mock_http_client, mock_token_manager):
     """Fixture to create an instance of B2C with mocked dependencies."""
     return B2C(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def valid_b2c_request():
     """Return a valid B2CRequest instance."""
@@ -53,7 +33,6 @@ def valid_b2c_request():
         ResultURL="https://example.com/result",
         Occasion="JuneSalary",
     )
-
 
 def test_send_payment_success(b2c, mock_http_client):
     """Test that a successful B2C payment can be performed."""
@@ -80,7 +59,6 @@ def test_send_payment_success(b2c, mock_http_client):
     assert args[0] == "/mpesa/b2c/v3/paymentrequest"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_send_payment_http_error(b2c, mock_http_client):
     """Test that B2C payment handles HTTP errors gracefully."""
     request = valid_b2c_request()
@@ -89,7 +67,6 @@ def test_send_payment_http_error(b2c, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         b2c.send_payment(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_b2c_response_is_successful_zero_code():
     """Test is_successful returns True for ResponseCode '0'."""
@@ -101,7 +78,6 @@ def test_b2c_response_is_successful_zero_code():
     )
     assert resp.is_successful() is True
 
-
 def test_b2c_response_is_successful_all_zeros():
     """Test is_successful returns True for ResponseCode '00000000'."""
     resp = B2CResponse(
@@ -111,7 +87,6 @@ def test_b2c_response_is_successful_all_zeros():
         ResponseDescription="Accept the service request successfully.",
     )
     assert resp.is_successful() is True
-
 
 def test_b2c_response_is_successful_non_zero_code():
     """Test is_successful returns False for non-success ResponseCode."""
@@ -123,7 +98,6 @@ def test_b2c_response_is_successful_non_zero_code():
     )
     assert resp.is_successful() is False
 
-
 def test_b2c_response_is_successful_mixed_code():
     """Test is_successful returns False for mixed ResponseCode like '00001'."""
     resp = B2CResponse(
@@ -134,7 +108,6 @@ def test_b2c_response_is_successful_mixed_code():
     )
     assert resp.is_successful() is False
 
-
 def test_b2c_response_is_successful_empty_code():
     """Test is_successful returns False for empty ResponseCode."""
     resp = B2CResponse(
@@ -144,7 +117,6 @@ def test_b2c_response_is_successful_empty_code():
         ResponseDescription="Failed.",
     )
     assert resp.is_successful() is False
-
 
 @pytest.mark.parametrize("invalid_command_id", ["InvalidCommand", "", None])
 def test_b2c_request_invalid_command_id_raises(invalid_command_id):
@@ -165,7 +137,6 @@ def test_b2c_request_invalid_command_id_raises(invalid_command_id):
         B2CRequest(**kwargs)
     assert "CommandID must be one of" in str(excinfo.value)
 
-
 def test_b2c_request_invalid_partyb_raises():
     """Test that B2CRequest raises ValueError for invalid PartyB phone number."""
     kwargs = dict(
@@ -184,7 +155,6 @@ def test_b2c_request_invalid_partyb_raises():
         B2CRequest(**kwargs)
     assert "PartyB must be a valid Kenyan phone number" in str(excinfo.value)
 
-
 def test_b2c_request_remarks_too_long_raises():
     """Test that B2CRequest raises ValueError for Remarks > 100 chars."""
     kwargs = dict(
@@ -202,7 +172,6 @@ def test_b2c_request_remarks_too_long_raises():
     with pytest.raises(ValueError) as excinfo:
         B2CRequest(**kwargs)
     assert "Remarks must not exceed 100 characters." in str(excinfo.value)
-
 
 def test_b2c_request_occasion_too_long_raises():
     """Test that B2CRequest raises ValueError for Occasion > 100 chars."""
@@ -223,11 +192,9 @@ def test_b2c_request_occasion_too_long_raises():
         B2CRequest(**kwargs)
     assert "Occasion must not exceed 100 characters." in str(excinfo.value)
 
-
 def make_result_parameters(params):
     """Helper to create list of B2CResultParameter from dict."""
     return [B2CResultParameter(Key=k, Value=v) for k, v in params.items()]
-
 
 def test_result_metadata_properties_all_present():
     """Test that B2CResultMetadata properties are correctly parsed."""
@@ -259,7 +226,6 @@ def test_result_metadata_properties_all_present():
     assert meta.utility_account_available_funds == 2000.0
     assert meta.working_account_available_funds == 10000.0
 
-
 def test_result_metadata_properties_some_missing():
     """Test that B2CResultMetadata handles missing parameters gracefully."""
     params = {
@@ -285,7 +251,6 @@ def test_result_metadata_properties_some_missing():
     assert meta.utility_account_available_funds is None
     assert meta.working_account_available_funds is None
 
-
 def test_result_metadata_properties_none_parameters():
     """Test that B2CResultMetadata handles None parameters correctly."""
     meta = B2CResultMetadata(
@@ -306,7 +271,6 @@ def test_result_metadata_properties_none_parameters():
     assert meta.utility_account_available_funds is None
     assert meta.working_account_available_funds is None
 
-
 def test_result_metadata_recipient_is_registered_none():
     """Test that B2CResultMetadata handles invalid recipient_is_registered value."""
     params = {
@@ -324,7 +288,6 @@ def test_result_metadata_recipient_is_registered_none():
         ResultParameters=make_result_parameters(params),
     )
     assert meta.recipient_is_registered is None
-
 
 def test_result_callback_schema():
     """Test that B2CResultCallback schema is correctly instantiated."""
@@ -346,7 +309,6 @@ def test_result_callback_schema():
     assert callback.Result.transaction_amount == 1000
     assert callback.Result.transaction_receipt == "LKXXXX1234"
 
-
 def test_result_callback_is_successful_zero_code():
     """Test is_successful returns True for ResultCode 0."""
     meta = B2CResultMetadata(
@@ -360,7 +322,6 @@ def test_result_callback_is_successful_zero_code():
     )
     callback = B2CResultCallback(Result=meta)
     assert callback.is_successful() is True
-
 
 def test_result_callback_is_successful_all_zeros():
     """Test is_successful returns True for ResultCode as string of zeros."""
@@ -378,7 +339,6 @@ def test_result_callback_is_successful_all_zeros():
     callback.Result.ResultCode = 0
     assert callback.is_successful() is True
 
-
 def test_result_callback_is_successful_non_zero_code():
     """Test is_successful returns False for non-zero ResultCode."""
     meta = B2CResultMetadata(
@@ -392,7 +352,6 @@ def test_result_callback_is_successful_non_zero_code():
     )
     callback = B2CResultCallback(Result=meta)
     assert callback.is_successful() is False
-
 
 def test_result_callback_is_successful_mixed_code():
     """Test is_successful returns False for mixed code like 00001."""
@@ -408,7 +367,6 @@ def test_result_callback_is_successful_mixed_code():
     callback = B2CResultCallback(Result=meta)
     assert callback.is_successful() is False
 
-
 def test_result_callback_is_successful_negative_code():
     """Test is_successful returns False for negative ResultCode."""
     meta = B2CResultMetadata(
@@ -423,30 +381,12 @@ def test_result_callback_is_successful_negative_code():
     callback = B2CResultCallback(Result=meta)
     assert callback.is_successful() is False
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=AsyncTokenManager)
-    mock.get_token = AsyncMock(return_value="test_token_async")
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing."""
-    mock = MagicMock(spec=AsyncHttpClient)
-    mock.post = AsyncMock()
-    return mock
-
-
 @pytest.fixture
 def async_b2c(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an instance of AsyncB2C with mocked dependencies."""
     return AsyncB2C(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_send_payment_success(
@@ -473,7 +413,6 @@ async def test_async_send_payment_success(
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 @pytest.mark.asyncio
 async def test_async_send_payment_token_error(
     async_b2c, mock_async_http_client, mock_async_token_manager
@@ -485,7 +424,6 @@ async def test_async_send_payment_token_error(
     with pytest.raises(Exception) as excinfo:
         await async_b2c.send_payment(request)
     assert "Token error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_send_payment_post_error(

--- a/tests/unit/b2c_account_top_up/test_b2c_account_top_up.py
+++ b/tests/unit/b2c_account_top_up/test_b2c_account_top_up.py
@@ -4,11 +4,8 @@ This module tests the B2C Account TopUp API client, ensuring it can initiate top
 process responses correctly, and manage callback/error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.b2c_account_top_up import (
     AsyncB2CAccountTopUp,
     B2CAccountTopUp,
@@ -19,22 +16,6 @@ from mpesakit.b2c_account_top_up import (
     B2CAccountTopUpTimeoutCallback,
     B2CAccountTopUpTimeoutCallbackResponse,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def b2c_account_topup(mock_http_client, mock_token_manager):
@@ -42,7 +23,6 @@ def b2c_account_topup(mock_http_client, mock_token_manager):
     return B2CAccountTopUp(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_b2c_account_topup_request():
     """Create a valid B2CAccountTopUpRequest for testing."""
@@ -58,7 +38,6 @@ def valid_b2c_account_topup_request():
         QueueTimeOutURL="https://mydomain/path/timeout",
         ResultURL="https://mydomain/path/result",
     )
-
 
 def test_topup_success(b2c_account_topup, mock_http_client):
     """Test that topup request is acknowledged and successful."""
@@ -78,7 +57,6 @@ def test_topup_success(b2c_account_topup, mock_http_client):
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 def test_topup_http_error(b2c_account_topup, mock_http_client):
     """Test handling of HTTP errors during topup request."""
     request = valid_b2c_account_topup_request()
@@ -86,7 +64,6 @@ def test_topup_http_error(b2c_account_topup, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         b2c_account_topup.topup(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_b2c_account_topup_success_callback():
     """Test parsing of a successful B2C Account TopUp callback."""
@@ -117,7 +94,6 @@ def test_b2c_account_topup_success_callback():
     assert callback.Result.TransactionID == "QKA81LK5CY"
     assert callback.Result.ResultDesc.startswith("The service request is processed")
 
-
 def test_b2c_account_topup_fail_callback():
     """Test parsing of a failed B2C Account TopUp callback."""
     payload = {
@@ -135,13 +111,11 @@ def test_b2c_account_topup_fail_callback():
     assert "cancelled" in callback.Result.ResultDesc
     assert callback.Result.TransactionID == "TX123456"
 
-
 def test_b2c_account_topup_callback_response():
     """Test the response schema for B2C Account TopUp callback."""
     resp = B2CAccountTopUpCallbackResponse()
     assert resp.ResultCode == 0
     assert "processed successfully" in resp.ResultDesc
-
 
 def test_b2c_account_topup_timeout_callback():
     """Test parsing of a B2C Account TopUp timeout callback."""
@@ -159,13 +133,11 @@ def test_b2c_account_topup_timeout_callback():
     assert callback.Result.ResultCode == "1"
     assert "timed out" in callback.Result.ResultDesc
 
-
 def test_b2c_account_topup_timeout_callback_response():
     """Test the response schema for B2C Account TopUp timeout callback."""
     resp = B2CAccountTopUpTimeoutCallbackResponse()
     assert resp.ResultCode == 0
     assert "Timeout notification received" in resp.ResultDesc
-
 
 @pytest.mark.parametrize("result_code_str, expected", [("0", True), ("1", False)])
 def test_b2c_account_topup_string_result_code_is_successful(result_code_str, expected):
@@ -184,28 +156,12 @@ def test_b2c_account_topup_string_result_code_is_successful(result_code_str, exp
     # Should not raise a TypeError when comparing string vs int inside is_successful
     assert callback.is_successful() is expected
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_async_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_b2c_account_topup(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncB2CAccountTopUp instance with mocked dependencies."""
     return AsyncB2CAccountTopUp(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_topup_success(
@@ -228,7 +184,6 @@ async def test_async_topup_success(
     assert response.is_successful() is True
     assert response.ResponseCode == response_data["ResponseCode"]
 
-
 @pytest.mark.asyncio
 async def test_async_topup_http_error(
     async_b2c_account_topup, mock_async_http_client, mock_async_token_manager
@@ -241,7 +196,6 @@ async def test_async_topup_http_error(
     with pytest.raises(Exception) as excinfo:
         await async_b2c_account_topup.topup(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_topup_token_retrieval(

--- a/tests/unit/bill_manager/test_bill_manager.py
+++ b/tests/unit/bill_manager/test_bill_manager.py
@@ -5,12 +5,10 @@ invoicing, cancellation, and error cases.
 """
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.bill_manager.bill_manager import AsyncBillManager, BillManager
 from mpesakit.bill_manager.schemas import (
     BillManagerBulkInvoiceRequest,
@@ -25,22 +23,6 @@ from mpesakit.bill_manager.schemas import (
     BillManagerUpdateOptInRequest,
     BillManagerUpdateOptInResponse,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager for testing purposes."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing purposes."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def bill_manager(mock_http_client, mock_token_manager):
@@ -50,7 +32,6 @@ def bill_manager(mock_http_client, mock_token_manager):
         token_manager=mock_token_manager,
         app_key="test_app_key",
     )
-
 
 def valid_opt_in_request():
     """Creates a valid opt-in request for Bill Manager."""
@@ -63,7 +44,6 @@ def valid_opt_in_request():
         callbackurl="http://my.server.com/bar/callback",
     )
 
-
 def valid_update_opt_in_request():
     """Creates a valid update opt-in request for Bill Manager."""
     return BillManagerUpdateOptInRequest(
@@ -74,7 +54,6 @@ def valid_update_opt_in_request():
         logo="image",
         callbackurl="http://my.server.com/bar/callback",
     )
-
 
 def valid_single_invoice_request():
     """Creates a valid single invoice request for Bill Manager."""
@@ -93,16 +72,13 @@ def valid_single_invoice_request():
         ],
     )
 
-
 def valid_bulk_invoice_request():
     """Creates a valid bulk invoice request for Bill Manager."""
     return BillManagerBulkInvoiceRequest(invoices=[valid_single_invoice_request()])
 
-
 def valid_cancel_single_invoice_request():
     """Creates a valid cancel single invoice request for Bill Manager."""
     return BillManagerCancelSingleInvoiceRequest(externalReference="113")
-
 
 def valid_cancel_bulk_invoice_request():
     """Creates a valid cancel bulk invoice request for Bill Manager."""
@@ -112,7 +88,6 @@ def valid_cancel_bulk_invoice_request():
             BillManagerCancelSingleInvoiceRequest(externalReference="114"),
         ]
     )
-
 
 def test_opt_in_success(bill_manager, mock_http_client):
     """Test successful opt-in to Bill Manager."""
@@ -128,7 +103,6 @@ def test_opt_in_success(bill_manager, mock_http_client):
     assert response.app_key == response_data["app_key"]
     assert response.rescode == "200"
 
-
 def test_update_opt_in_success(bill_manager, mock_http_client):
     """Test successful update of opt-in settings for Bill Manager."""
     request = valid_update_opt_in_request()
@@ -140,7 +114,6 @@ def test_update_opt_in_success(bill_manager, mock_http_client):
     response = bill_manager.update_opt_in(request)
     assert isinstance(response, BillManagerUpdateOptInResponse)
     assert response.rescode == "200"
-
 
 def test_send_single_invoice_success(bill_manager, mock_http_client):
     """Test sending a single invoice via Bill Manager."""
@@ -156,7 +129,6 @@ def test_send_single_invoice_success(bill_manager, mock_http_client):
     assert response.is_successful() is True
     assert response.Status_Message == response_data["Status_Message"]
 
-
 def test_send_bulk_invoice_success(bill_manager, mock_http_client):
     """Test sending multiple invoices via Bill Manager."""
     request = valid_bulk_invoice_request()
@@ -169,7 +141,6 @@ def test_send_bulk_invoice_success(bill_manager, mock_http_client):
     response = bill_manager.send_bulk_invoice(request)
     assert isinstance(response, BillManagerBulkInvoiceResponse)
     assert response.Status_Message == response_data["Status_Message"]
-
 
 def test_cancel_single_invoice_success(bill_manager, mock_http_client):
     """Test cancelling a single invoice via Bill Manager."""
@@ -186,7 +157,6 @@ def test_cancel_single_invoice_success(bill_manager, mock_http_client):
     assert response.is_successful() is True
     assert response.Status_Message == response_data["Status_Message"]
 
-
 def test_cancel_bulk_invoice_success(bill_manager, mock_http_client):
     """Test cancelling multiple invoices via Bill Manager."""
     request = valid_cancel_bulk_invoice_request()
@@ -201,7 +171,6 @@ def test_cancel_bulk_invoice_success(bill_manager, mock_http_client):
     assert isinstance(response, BillManagerCancelInvoiceResponse)
     assert response.Status_Message == response_data["Status_Message"]
 
-
 def test_bill_manager_http_error(bill_manager, mock_http_client):
     """Test handling of HTTP errors when sending a single invoice."""
     request = valid_single_invoice_request()
@@ -209,7 +178,6 @@ def test_bill_manager_http_error(bill_manager, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         bill_manager.send_single_invoice(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_app_key_required_for_invoice(mock_http_client, mock_token_manager):
     """Test app_key requirement for sending a single invoice."""
@@ -220,7 +188,6 @@ def test_app_key_required_for_invoice(mock_http_client, mock_token_manager):
     with pytest.raises(ValueError) as excinfo:
         manager.send_single_invoice(request)
     assert "app_key must be set" in str(excinfo.value)
-
 
 @pytest.mark.parametrize(
     "due_date,expected",
@@ -278,7 +245,6 @@ def test_due_date_valid_formats(due_date, expected):
         microsecond=(dt_result.microsecond // 10000) * 10000
     ) == dt_expected.replace(microsecond=(dt_expected.microsecond // 10000) * 10000)
 
-
 @pytest.mark.parametrize(
     "due_date",
     [
@@ -308,7 +274,6 @@ def test_due_date_invalid_formats_raise(due_date):
         BillManagerSingleInvoiceRequest(**req)
     assert "validation error" in str(excinfo.value)
 
-
 def test_due_date_missing_raises():
     """Test missing dueDate raises ValueError."""
     req = {
@@ -326,7 +291,6 @@ def test_due_date_missing_raises():
         BillManagerSingleInvoiceRequest.model_validate(req)
     assert "dueDate is required" in str(excinfo.value)
 
-
 def test_billed_period_invalid_raises():
     """Test invalid billedPeriod raises ValueError."""
     req = {
@@ -343,7 +307,6 @@ def test_billed_period_invalid_raises():
     with pytest.raises(ValueError) as excinfo:
         BillManagerSingleInvoiceRequest(**req)
     assert "billedPeriod" in str(excinfo.value)
-
 
 def test_result_code_as_string_does_not_raise(bill_manager, mock_http_client):
     """Ensure response.resultCode as a string does not cause type errors in is_successful."""
@@ -364,21 +327,6 @@ def test_result_code_as_string_does_not_raise(bill_manager, mock_http_client):
     is_success = response.is_successful()
     assert isinstance(is_success, bool)
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager for testing purposes."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_async_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing purposes."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_bill_manager(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncBillManager instance with mocked AsyncHttpClient and AsyncTokenManager."""
@@ -387,7 +335,6 @@ def async_bill_manager(mock_async_http_client, mock_async_token_manager):
         token_manager=mock_async_token_manager,
         app_key="test_app_key",
     )
-
 
 @pytest.mark.asyncio
 async def test_async_opt_in_success(async_bill_manager, mock_async_http_client):
@@ -404,7 +351,6 @@ async def test_async_opt_in_success(async_bill_manager, mock_async_http_client):
     assert response.app_key == response_data["app_key"]
     assert response.rescode == "200"
 
-
 @pytest.mark.asyncio
 async def test_async_update_opt_in_success(async_bill_manager, mock_async_http_client):
     """Test successful async update of opt-in settings for Bill Manager."""
@@ -417,7 +363,6 @@ async def test_async_update_opt_in_success(async_bill_manager, mock_async_http_c
     response = await async_bill_manager.update_opt_in(request)
     assert isinstance(response, BillManagerUpdateOptInResponse)
     assert response.rescode == "200"
-
 
 @pytest.mark.asyncio
 async def test_async_send_single_invoice_success(
@@ -436,7 +381,6 @@ async def test_async_send_single_invoice_success(
     assert response.is_successful() is True
     assert response.Status_Message == response_data["Status_Message"]
 
-
 @pytest.mark.asyncio
 async def test_async_send_bulk_invoice_success(
     async_bill_manager, mock_async_http_client
@@ -452,7 +396,6 @@ async def test_async_send_bulk_invoice_success(
     response = await async_bill_manager.send_bulk_invoice(request)
     assert isinstance(response, BillManagerBulkInvoiceResponse)
     assert response.Status_Message == response_data["Status_Message"]
-
 
 @pytest.mark.asyncio
 async def test_async_cancel_single_invoice_success(
@@ -472,7 +415,6 @@ async def test_async_cancel_single_invoice_success(
     assert response.is_successful() is True
     assert response.Status_Message == response_data["Status_Message"]
 
-
 @pytest.mark.asyncio
 async def test_async_cancel_bulk_invoice_success(
     async_bill_manager, mock_async_http_client
@@ -490,7 +432,6 @@ async def test_async_cancel_bulk_invoice_success(
     assert isinstance(response, BillManagerCancelInvoiceResponse)
     assert response.Status_Message == response_data["Status_Message"]
 
-
 @pytest.mark.asyncio
 async def test_async_bill_manager_http_error(
     async_bill_manager, mock_async_http_client
@@ -501,7 +442,6 @@ async def test_async_bill_manager_http_error(
     with pytest.raises(Exception) as excinfo:
         await async_bill_manager.send_single_invoice(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_app_key_required_for_invoice(

--- a/tests/unit/business_buy_goods/test_business_buy_goods.py
+++ b/tests/unit/business_buy_goods/test_business_buy_goods.py
@@ -4,11 +4,8 @@ This module tests the Business Buy Goods API client, ensuring it can handle paym
 process responses correctly, and manage error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.business_buy_goods import (
     AsyncBusinessBuyGoods,
     BusinessBuyGoods,
@@ -19,22 +16,6 @@ from mpesakit.business_buy_goods import (
     BusinessBuyGoodsTimeoutCallback,
     BusinessBuyGoodsTimeoutCallbackResponse,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def business_buy_goods(mock_http_client, mock_token_manager):
@@ -42,7 +23,6 @@ def business_buy_goods(mock_http_client, mock_token_manager):
     return BusinessBuyGoods(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_business_buy_goods_request():
     """Create a valid BusinessBuyGoodsRequest for testing."""
@@ -57,7 +37,6 @@ def valid_business_buy_goods_request():
         QueueTimeOutURL="https://mydomain.com/b2b/buygoods/queue/",
         ResultURL="https://mydomain.com/b2b/buygoods/result/",
     )
-
 
 def test_buy_goods_request_acknowledged(business_buy_goods, mock_http_client):
     """Test that buy goods request is acknowledged, not finalized."""
@@ -81,7 +60,6 @@ def test_buy_goods_request_acknowledged(business_buy_goods, mock_http_client):
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 def test_buy_goods_http_error(business_buy_goods, mock_http_client):
     """Test handling of HTTP errors during buy goods request."""
     request = valid_business_buy_goods_request()
@@ -89,7 +67,6 @@ def test_buy_goods_http_error(business_buy_goods, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         business_buy_goods.buy_goods(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_business_buy_goods_result_callback_success():
     """Test parsing of a successful business buy goods result callback."""
@@ -119,13 +96,11 @@ def test_business_buy_goods_result_callback_success():
     assert callback.Result.TransactionID == "QKA81LK5CY"
     assert callback.Result.ResultParameters.ResultParameter[0].Key == "Amount"
 
-
 def test_business_buy_goods_result_callback_response():
     """Test the response schema for result callback."""
     resp = BusinessBuyGoodsResultCallbackResponse()
     assert resp.ResultCode == 0
     assert "Callback received successfully" in resp.ResultDesc
-
 
 def test_business_buy_goods_timeout_callback():
     """Test parsing of a business buy goods timeout callback."""
@@ -143,13 +118,11 @@ def test_business_buy_goods_timeout_callback():
     assert callback.Result.ResultCode == 1
     assert "timed out" in callback.Result.ResultDesc
 
-
 def test_business_buy_goods_timeout_callback_response():
     """Test the response schema for timeout callback."""
     resp = BusinessBuyGoodsTimeoutCallbackResponse()
     assert resp.ResultCode == 0
     assert "Timeout notification received" in resp.ResultDesc
-
 
 def test_business_buy_goods_result_callback_resultcode_string():
     """Ensure a string ResultCode does not raise when checking success."""
@@ -176,28 +149,12 @@ def test_business_buy_goods_result_callback_resultcode_string():
     # Also assert it is considered successful.
     assert callback.is_successful() is True
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_business_buy_goods(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncBusinessBuyGoods instance with mocked dependencies."""
     return AsyncBusinessBuyGoods(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_buy_goods_request_acknowledged(
@@ -219,7 +176,6 @@ async def test_async_buy_goods_request_acknowledged(
     assert response.is_successful() is True
     assert response.ConversationID == response_data["ConversationID"]
 
-
 @pytest.mark.asyncio
 async def test_async_buy_goods_http_error(
     async_business_buy_goods, mock_async_http_client
@@ -232,7 +188,6 @@ async def test_async_buy_goods_http_error(
         await async_business_buy_goods.buy_goods(request)
 
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_buy_goods_token_manager_called(
@@ -251,7 +206,6 @@ async def test_async_buy_goods_token_manager_called(
     await async_business_buy_goods.buy_goods(request)
 
     mock_async_token_manager.get_token.assert_called_once()
-
 
 @pytest.mark.asyncio
 async def test_async_buy_goods_http_client_called_with_correct_params(

--- a/tests/unit/business_paybill/test_business_paybill.py
+++ b/tests/unit/business_paybill/test_business_paybill.py
@@ -4,11 +4,8 @@ This module tests the Business PayBill API client, ensuring it can handle paymen
 process responses correctly, and manage error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.business_paybill import (
     AsyncBusinessPayBill,
     BusinessPayBill,
@@ -19,22 +16,6 @@ from mpesakit.business_paybill import (
     BusinessPayBillTimeoutCallback,
     BusinessPayBillTimeoutCallbackResponse,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def business_paybill(mock_http_client, mock_token_manager):
@@ -42,7 +23,6 @@ def business_paybill(mock_http_client, mock_token_manager):
     return BusinessPayBill(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_business_paybill_request():
     """Create a valid BusinessPayBillRequest for testing."""
@@ -57,7 +37,6 @@ def valid_business_paybill_request():
         QueueTimeOutURL="https://mydomain.com/b2b/paybill/queue/",
         ResultURL="https://mydomain.com/b2b/paybill/result/",
     )
-
 
 def test_paybill_request_acknowledged(business_paybill, mock_http_client):
     """Test that paybill request is acknowledged, not finalized."""
@@ -81,7 +60,6 @@ def test_paybill_request_acknowledged(business_paybill, mock_http_client):
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 def test_paybill_http_error(business_paybill, mock_http_client):
     """Test handling of HTTP errors during paybill request."""
     request = valid_business_paybill_request()
@@ -89,7 +67,6 @@ def test_paybill_http_error(business_paybill, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         business_paybill.paybill(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_business_paybill_result_callback_success():
     """Test parsing of a successful business paybill result callback."""
@@ -119,13 +96,11 @@ def test_business_paybill_result_callback_success():
     assert callback.Result.TransactionID == "QKA81LK5CY"
     assert callback.Result.ResultParameters.ResultParameter[0].Key == "Amount"
 
-
 def test_business_paybill_result_callback_response():
     """Test the response schema for result callback."""
     resp = BusinessPayBillResultCallbackResponse()
     assert resp.ResultCode == 0
     assert "Callback received successfully" in resp.ResultDesc
-
 
 def test_business_paybill_timeout_callback():
     """Test parsing of a business paybill timeout callback."""
@@ -143,13 +118,11 @@ def test_business_paybill_timeout_callback():
     assert callback.Result.ResultCode == 1
     assert "timed out" in callback.Result.ResultDesc
 
-
 def test_business_paybill_timeout_callback_response():
     """Test the response schema for timeout callback."""
     resp = BusinessPayBillTimeoutCallbackResponse()
     assert resp.ResultCode == 0
     assert "Timeout notification received" in resp.ResultDesc
-
 
 def test_business_paybill_result_callback_with_string_result_code():
     """Ensure is_successful handles ResultCode provided as a string without raising TypeError."""
@@ -175,28 +148,12 @@ def test_business_paybill_result_callback_with_string_result_code():
     assert callback.is_successful() is True
     assert callback.Result.TransactionID == "QKA81LK5CY"
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_async_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_business_paybill(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncBusinessPayBill instance with mocked dependencies."""
     return AsyncBusinessPayBill(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_paybill_request_acknowledged(
@@ -221,7 +178,6 @@ async def test_async_paybill_request_acknowledged(
         response.OriginatorConversationID == response_data["OriginatorConversationID"]
     )
 
-
 @pytest.mark.asyncio
 async def test_async_paybill_http_error(async_business_paybill, mock_async_http_client):
     """Test handling of HTTP errors during async paybill request."""
@@ -230,7 +186,6 @@ async def test_async_paybill_http_error(async_business_paybill, mock_async_http_
     with pytest.raises(Exception) as excinfo:
         await async_business_paybill.paybill(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_paybill_token_retrieval(
@@ -252,4 +207,4 @@ async def test_async_paybill_token_retrieval(
     mock_async_http_client.post.assert_awaited_once()
     call_args = mock_async_http_client.post.call_args
     assert "Authorization" in call_args.kwargs["headers"]
-    assert "Bearer test_async_token" in call_args.kwargs["headers"]["Authorization"]
+    assert "Bearer test_token" in call_args.kwargs["headers"]["Authorization"]

--- a/tests/unit/c2b/test_c2b.py
+++ b/tests/unit/c2b/test_c2b.py
@@ -1,11 +1,9 @@
 """Unit tests for the C2B functionality of the Mpesa SDK."""
 
 import warnings
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.c2b import (
     C2B,
     AsyncC2B,
@@ -16,28 +14,11 @@ from mpesakit.c2b import (
     C2BValidationResponse,
     C2BValidationResultCodeType,
 )
-from mpesakit.http_client import AsyncHttpClient, HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def c2b(mock_http_client, mock_token_manager):
     """Fixture to create an instance of C2B with mocked dependencies."""
     return C2B(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def test_register_url_success(c2b, mock_http_client):
     """Test that a successful C2B URL registration can be performed."""
@@ -66,7 +47,6 @@ def test_register_url_success(c2b, mock_http_client):
     assert args[0] == "/mpesa/c2b/v1/registerurl"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_register_url_handles_typo_field(c2b, mock_http_client):
     """Test that the C2B URL registration handles the typo in the response field."""
     request = C2BRegisterUrlRequest(
@@ -88,7 +68,6 @@ def test_register_url_handles_typo_field(c2b, mock_http_client):
 
     assert response.OriginatorConversationID == "typo123"
 
-
 def test_register_url_handles_http_error(c2b, mock_http_client):
     """Test that the C2B URL registration handles HTTP errors gracefully."""
     request = C2BRegisterUrlRequest(
@@ -102,7 +81,6 @@ def test_register_url_handles_http_error(c2b, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         c2b.register_url(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_validate_payment_success(c2b):
     """Test that a C2B payment validation can be handled successfully."""
@@ -130,7 +108,6 @@ def test_validate_payment_success(c2b):
     assert response.ResultDesc == result_desc
     assert response.ThirdPartyTransID == "trans123"
 
-
 def test_validate_payment_rejected(c2b):
     """Test that a C2B payment validation can be handled as rejected."""
     request = C2BValidationRequest(
@@ -155,13 +132,11 @@ def test_validate_payment_rejected(c2b):
     assert response.ResultDesc == result_desc
     assert response.ThirdPartyTransID == "trans456"
 
-
 def test_confirm_payment_success(c2b):
     """Test that a C2B payment confirmation can be acknowledged successfully."""
     response = C2BConfirmationResponse()
     assert response.ResultCode == 0
     assert "Success" in response.ResultDesc
-
 
 def test_warn_invalid_urls_triggers_warning(monkeypatch):
     """Test that _warn_invalid_urls triggers a warning for forbidden keywords in URLs."""
@@ -189,7 +164,6 @@ def test_warn_invalid_urls_triggers_warning(monkeypatch):
     )
     assert all(call[1] is UserWarning for call in warn_calls)
 
-
 def test_warn_invalid_urls_no_warning(monkeypatch):
     """Test that _warn_invalid_urls does not trigger a warning for safe URLs."""
     warn_calls = []
@@ -204,7 +178,6 @@ def test_warn_invalid_urls_no_warning(monkeypatch):
     C2BRegisterUrlRequest._warn_invalid_urls(values)
 
     assert len(warn_calls) == 0
-
 
 def test_warn_invalid_urls_multiple_keywords(monkeypatch):
     """Test that _warn_invalid_urls triggers multiple warnings for multiple forbidden keywords."""
@@ -236,7 +209,6 @@ def test_warn_invalid_urls_multiple_keywords(monkeypatch):
         for call in warn_calls
     )
 
-
 def test_register_url_invalid_response_type_raises_value_error():
     """Test that C2BRegisterUrlRequest raises ValueError for invalid ResponseType."""
     invalid_response_type = "InvalidType"
@@ -252,7 +224,6 @@ def test_register_url_invalid_response_type_raises_value_error():
     assert "ResponseType must be one of" in str(excinfo.value)
     assert invalid_response_type in str(excinfo.value)
 
-
 def test_c2b_register_url_response_is_successful_zero_code():
     """Test is_successful returns True for ResponseCode '0'."""
     resp = C2BRegisterUrlResponse(
@@ -263,7 +234,6 @@ def test_c2b_register_url_response_is_successful_zero_code():
         ResponseCode="0",
     )
     assert resp.is_successful() is True
-
 
 def test_c2b_register_url_response_is_successful_all_zeros():
     """Test is_successful returns True for ResponseCode '00000000'."""
@@ -276,7 +246,6 @@ def test_c2b_register_url_response_is_successful_all_zeros():
     )
     assert resp.is_successful() is True
 
-
 def test_c2b_register_url_response_is_successful_non_zero_code():
     """Test is_successful returns False for non-success ResponseCode."""
     resp = C2BRegisterUrlResponse(
@@ -287,7 +256,6 @@ def test_c2b_register_url_response_is_successful_non_zero_code():
         ResponseCode="1",
     )
     assert resp.is_successful() is False
-
 
 def test_c2b_register_url_response_is_successful_mixed_code():
     """Test is_successful returns False for mixed ResponseCode like '00001'."""
@@ -300,7 +268,6 @@ def test_c2b_register_url_response_is_successful_mixed_code():
     )
     assert resp.is_successful() is False
 
-
 def test_c2b_register_url_response_is_successful_empty_code():
     """Test is_successful returns False for empty ResponseCode."""
     resp = C2BRegisterUrlResponse(
@@ -312,14 +279,12 @@ def test_c2b_register_url_response_is_successful_empty_code():
     )
     assert resp.is_successful() is False
 
-
 def test_validate_result_code_valid():
     """Test _validate_result_code accepts valid ResultCode values."""
     for code in [e.value for e in C2BValidationResultCodeType]:
         values = {"ResultCode": code}
         result = C2BValidationResponse._validate_result_code(values)
         assert result == values
-
 
 def test_validate_result_code_invalid():
     """Test _validate_result_code raises ValueError for invalid ResultCode."""
@@ -329,7 +294,6 @@ def test_validate_result_code_invalid():
         C2BValidationResponse._validate_result_code(values)
     assert f"ResultCode must be one of {valid_codes}" in str(excinfo.value)
     assert "INVALID_CODE" in str(excinfo.value)
-
 
 def test_warn_long_resultdesc_triggers_warning(monkeypatch):
     """Test _warn_long_resultdesc triggers a warning if ResultDesc exceeds 90 chars."""
@@ -344,7 +308,6 @@ def test_warn_long_resultdesc_triggers_warning(monkeypatch):
     assert all(call[1] is UserWarning for call in warn_calls)
     assert result == values
 
-
 def test_warn_long_resultdesc_no_warning(monkeypatch):
     """Test _warn_long_resultdesc does not trigger warning for <= 90 chars."""
     warn_calls = []
@@ -357,7 +320,6 @@ def test_warn_long_resultdesc_no_warning(monkeypatch):
     assert len(warn_calls) == 0
     assert result == values
 
-
 def test_warn_long_resultdesc_none(monkeypatch):
     """Test _warn_long_resultdesc does not warn if ResultDesc is None."""
     warn_calls = []
@@ -368,7 +330,6 @@ def test_warn_long_resultdesc_none(monkeypatch):
     result = C2BValidationResponse._warn_long_resultdesc(values)
     assert len(warn_calls) == 0
     assert result == values
-
 
 def test_is_successful_with_mixed_string_response_code_no_type_error():
     """Ensure is_successful handles mixed/numeric-like string ResponseCode without TypeError and returns False for non-success codes."""
@@ -388,28 +349,12 @@ def test_is_successful_with_mixed_string_response_code_no_type_error():
     assert isinstance(result, bool)
     assert result is False
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token for testing."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_async_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_c2b(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an instance of AsyncC2B with mocked dependencies."""
     return AsyncC2B(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_register_url_success(async_c2b, mock_async_http_client):
@@ -437,8 +382,7 @@ async def test_async_register_url_success(async_c2b, mock_async_http_client):
     mock_async_http_client.post.assert_called_once()
     args, kwargs = mock_async_http_client.post.call_args
     assert args[0] == "/mpesa/c2b/v1/registerurl"
-    assert kwargs["headers"]["Authorization"] == "Bearer test_async_token"
-
+    assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
 @pytest.mark.asyncio
 async def test_async_register_url_handles_typo_field(async_c2b, mock_async_http_client):
@@ -461,7 +405,6 @@ async def test_async_register_url_handles_typo_field(async_c2b, mock_async_http_
     response = await async_c2b.register_url(request)
 
     assert response.OriginatorConversationID == "typo123"
-
 
 @pytest.mark.asyncio
 async def test_async_register_url_handles_http_error(async_c2b, mock_async_http_client):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,35 @@
+"""Shared fixtures for unit tests."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from mpesakit.auth import AsyncTokenManager, TokenManager
+from mpesakit.http_client import AsyncHttpClient, HttpClient
+
+
+@pytest.fixture
+def mock_token_manager():
+    """Mock TokenManager to return a fixed token."""
+    mock = MagicMock(spec=TokenManager)
+    mock.get_token.return_value = "test_token"
+    return mock
+
+
+@pytest.fixture
+def mock_http_client():
+    """Mock HttpClient to simulate HTTP requests."""
+    return MagicMock(spec=HttpClient)
+
+
+@pytest.fixture
+def mock_async_token_manager():
+    """Mock AsyncTokenManager to return a fixed token."""
+    mock = AsyncMock(spec=AsyncTokenManager)
+    mock.get_token.return_value = "test_token"
+    return mock
+
+
+@pytest.fixture
+def mock_async_http_client():
+    """Mock AsyncHttpClient to simulate async HTTP requests."""
+    return AsyncMock(spec=AsyncHttpClient)

--- a/tests/unit/dynamic_qr_code/test_dynamic_qr_code.py
+++ b/tests/unit/dynamic_qr_code/test_dynamic_qr_code.py
@@ -1,38 +1,18 @@
 """Unit tests for the Dynamic QR Code functionality of the Mpesa SDK."""
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
 from mpesakit.dynamic_qr_code import (
     AsyncDynamicQRCode,
     DynamicQRCode,
     DynamicQRGenerateRequest,
     DynamicQRTransactionType,
 )
-from mpesakit.http_client import AsyncHttpClient, MpesaHttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock MpesaHttpClient for testing."""
-    return MagicMock(spec=MpesaHttpClient)
-
 
 @pytest.fixture
 def dynamic_qr_service(mock_http_client, mock_token_manager):
     """Fixture to create an instance of DynamicQRCode with mocked dependencies."""
     return DynamicQRCode(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def test_generate_dynamic_qr_success(dynamic_qr_service, mock_http_client):
     """Test successful Dynamic QR Code generation."""
@@ -66,7 +46,6 @@ def test_generate_dynamic_qr_success(dynamic_qr_service, mock_http_client):
     assert "Authorization" in kwargs["headers"]
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_generate_dynamic_qr_handles_http_error(dynamic_qr_service, mock_http_client):
     """Test that an HTTP error during Dynamic QR Code generation is handled."""
     request = DynamicQRGenerateRequest(
@@ -83,7 +62,6 @@ def test_generate_dynamic_qr_handles_http_error(dynamic_qr_service, mock_http_cl
         dynamic_qr_service.generate(request)
     assert "HTTP error" in str(excinfo.value)
 
-
 def test_generate_dynamic_qr_invalid_trx_code():
     """Test that providing an invalid TrxCode raises a ValueError."""
     # Use an invalid TrxCode value
@@ -98,7 +76,6 @@ def test_generate_dynamic_qr_invalid_trx_code():
             Size="300",
         )
     assert "TrxCode must be one of:" in str(excinfo.value)
-
 
 def test_generate_dynamic_qr_send_money_cpi_normalization(monkeypatch):
     """Test CPI normalization for SEND_MONEY TrxCode."""
@@ -157,7 +134,6 @@ def test_generate_dynamic_qr_send_money_cpi_normalization(monkeypatch):
         excinfo.value
     )
 
-
 def test_generate_dynamic_qr_string_response_code_no_type_error(
     dynamic_qr_service, mock_http_client
 ):
@@ -182,30 +158,12 @@ def test_generate_dynamic_qr_string_response_code_no_type_error(
     response = dynamic_qr_service.generate(request)
     assert response.is_successful() is True
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=AsyncTokenManager)
-    mock.get_token = AsyncMock(return_value="test_async_token")
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing."""
-    mock = MagicMock(spec=AsyncHttpClient)
-    mock.post = AsyncMock()
-    return mock
-
-
 @pytest.fixture
 def async_dynamic_qr_service(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an instance of AsyncDynamicQRCode with mocked dependencies."""
     return AsyncDynamicQRCode(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_generate_dynamic_qr_success(
@@ -237,8 +195,7 @@ async def test_async_generate_dynamic_qr_success(
     mock_async_http_client.post.assert_called_once()
     args, kwargs = mock_async_http_client.post.call_args
     assert "Authorization" in kwargs["headers"]
-    assert kwargs["headers"]["Authorization"] == "Bearer test_async_token"
-
+    assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
 @pytest.mark.asyncio
 async def test_async_generate_dynamic_qr_handles_http_error(
@@ -258,7 +215,6 @@ async def test_async_generate_dynamic_qr_handles_http_error(
     with pytest.raises(Exception) as excinfo:
         await async_dynamic_qr_service.generate(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_generate_dynamic_qr_token_manager_called(

--- a/tests/unit/mpesa_express/test_stk_push.py
+++ b/tests/unit/mpesa_express/test_stk_push.py
@@ -3,12 +3,8 @@
 This module tests the StkPush class for initiating and querying M-Pesa STK Push transactions.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
 from mpesakit.mpesa_express.stk_push import (
     AsyncStkPush,
     StkPush,
@@ -18,26 +14,10 @@ from mpesakit.mpesa_express.stk_push import (
     StkPushSimulateResponse,
 )
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def stk_push(mock_http_client, mock_token_manager):
     """Fixture to create an instance of StkPush with mocked dependencies."""
     return StkPush(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def test_push_success(stk_push, mock_http_client):
     """Test that a successful STK Push transaction can be initiated."""
@@ -73,7 +53,6 @@ def test_push_success(stk_push, mock_http_client):
     assert args[0] == "/mpesa/stkpush/v1/processrequest"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_query_success(stk_push, mock_http_client):
     """Test that the status of an STK Push transaction can be queried successfully."""
     request = StkPushQueryRequest(
@@ -102,7 +81,6 @@ def test_query_success(stk_push, mock_http_client):
     assert args[0] == "/mpesa/stkpushquery/v1/query"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_push_handles_http_error(stk_push, mock_http_client):
     """Test that an HTTP error during STK Push initiation is handled."""
     request = StkPushSimulateRequest(
@@ -124,7 +102,6 @@ def test_push_handles_http_error(stk_push, mock_http_client):
         stk_push.push(request)
     assert "HTTP error" in str(excinfo.value)
 
-
 def test_query_handles_http_error(stk_push, mock_http_client):
     """Test that an HTTP error during STK Push query is handled."""
     request = StkPushQueryRequest(
@@ -138,7 +115,6 @@ def test_query_handles_http_error(stk_push, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         stk_push.query(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_stk_push_simulate_request_invalid_transaction_type():
     """Test that StkPushSimulateRequest raises ValueError for invalid TransactionType."""
@@ -160,28 +136,12 @@ def test_stk_push_simulate_request_invalid_transaction_type():
         StkPushSimulateRequest(**valid_kwargs)
     assert "TransactionType must be one of:" in str(excinfo.value)
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token for testing."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient for testing."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_stk_push(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an instance of AsyncStkPush with mocked dependencies."""
     return AsyncStkPush(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_push_success(
@@ -220,7 +180,6 @@ async def test_async_push_success(
     assert args[0] == "/mpesa/stkpush/v1/processrequest"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 @pytest.mark.asyncio
 async def test_async_query_success(
     async_stk_push, mock_async_http_client, mock_async_token_manager
@@ -252,7 +211,6 @@ async def test_async_query_success(
     assert args[0] == "/mpesa/stkpushquery/v1/query"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 @pytest.mark.asyncio
 async def test_async_push_handles_http_error(async_stk_push, mock_async_http_client):
     """Test that an HTTP error during async STK Push initiation is handled."""
@@ -274,7 +232,6 @@ async def test_async_push_handles_http_error(async_stk_push, mock_async_http_cli
     with pytest.raises(Exception) as excinfo:
         await async_stk_push.push(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_query_handles_http_error(async_stk_push, mock_async_http_client):

--- a/tests/unit/mpesa_ratiba/test_mpesa_ratiba.py
+++ b/tests/unit/mpesa_ratiba/test_mpesa_ratiba.py
@@ -4,12 +4,8 @@ This module tests the Standing Order API client, ensuring it can initiate standi
 process responses correctly, and manage callback/error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
 from mpesakit.mpesa_ratiba import (
     AsyncMpesaRatiba,
     FrequencyEnum,
@@ -22,26 +18,10 @@ from mpesakit.mpesa_ratiba import (
     TransactionTypeEnum,
 )
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def mpesa_ratiba(mock_http_client, mock_token_manager):
     """Fixture to create a MpesaRatiba instance with mocked dependencies."""
     return MpesaRatiba(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def valid_standing_order_request():
     """Create a valid StandingOrderRequest for testing."""
@@ -59,7 +39,6 @@ def valid_standing_order_request():
         TransactionDesc="Electric Bike",
         Frequency=FrequencyEnum.DAILY,
     )
-
 
 def test_create_standing_order_success(mpesa_ratiba, mock_http_client):
     """Test that standing order request is acknowledged and successful."""
@@ -91,7 +70,6 @@ def test_create_standing_order_success(mpesa_ratiba, mock_http_client):
         == response_data["ResponseHeader"]["responseDescription"]
     )
 
-
 def test_create_standing_order_http_error(mpesa_ratiba, mock_http_client):
     """Test handling of HTTP errors during standing order request."""
     request = valid_standing_order_request()
@@ -99,7 +77,6 @@ def test_create_standing_order_http_error(mpesa_ratiba, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         mpesa_ratiba.create_standing_order(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_standing_order_success_callback():
     """Test parsing of a successful Standing Order callback."""
@@ -131,7 +108,6 @@ def test_standing_order_success_callback():
         for item in callback.ResponseBody.ResponseData
     )
 
-
 def test_standing_order_fail_callback():
     """Test parsing of a failed Standing Order callback."""
     payload = {
@@ -161,13 +137,11 @@ def test_standing_order_fail_callback():
         for item in callback.ResponseBody.ResponseData
     )
 
-
 def test_standing_order_callback_response():
     """Test the response schema for Standing Order callback."""
     resp = StandingOrderCallbackResponse()
     assert resp.ResultCode == "0"
     assert "processed successfully" in resp.ResultDesc
-
 
 def test_standing_order_request_invalid_date_format():
     """Test StandingOrderRequest raises ValueError for invalid date format."""
@@ -188,7 +162,6 @@ def test_standing_order_request_invalid_date_format():
         )
     assert "Date must be in 'yyyymmdd' format" in str(excinfo.value)
 
-
 def test_standing_order_request_invalid_date_value():
     """Test StandingOrderRequest raises ValueError for invalid date value."""
     with pytest.raises(ValueError) as excinfo:
@@ -208,7 +181,6 @@ def test_standing_order_request_invalid_date_value():
         )
     assert "Date must be in 'yyyymmdd' format" in str(excinfo.value)
 
-
 def test_standing_order_request_other_date_value():
     """Test StandingOrderRequest raises ValueError for invalid date value."""
     request = StandingOrderRequest(
@@ -226,7 +198,6 @@ def test_standing_order_request_other_date_value():
         Frequency=FrequencyEnum.MONTHLY,
     )
     assert request.StartDate == "20241205"  # Should normalize to yyyymmdd format
-
 
 def test_invalid_phone_number():
     """Test that invalid phone numbers raise ValueError."""
@@ -246,7 +217,6 @@ def test_invalid_phone_number():
             Frequency=FrequencyEnum.MONTHLY,
         )
     assert "Invalid PartyA phone number" in str(excinfo.value)
-
 
 def test_callback_resultcode_as_string_handled_gracefully():
     """Ensure StandingOrderCallback.is_successful() handles responseCode as a string without TypeError."""
@@ -275,28 +245,12 @@ def test_callback_resultcode_as_string_handled_gracefully():
         )
     assert result is True
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_mpesa_ratiba(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncMpesaRatiba instance with mocked dependencies."""
     return AsyncMpesaRatiba(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_create_standing_order_success_async(
@@ -330,7 +284,6 @@ async def test_create_standing_order_success_async(
         response.ResponseHeader.responseDescription
         == response_data["ResponseHeader"]["responseDescription"]
     )
-
 
 @pytest.mark.asyncio
 async def test_create_standing_order_http_error_async(

--- a/tests/unit/reversal/test_reversal.py
+++ b/tests/unit/reversal/test_reversal.py
@@ -4,12 +4,8 @@ This module tests the Reversal API client, ensuring it can handle reversal reque
 process responses correctly, and manage error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
 from mpesakit.reversal import (
     ReversalRequest,
     ReversalResponse,
@@ -20,26 +16,10 @@ from mpesakit.reversal import (
 )
 from mpesakit.reversal.reversal import AsyncReversal, Reversal
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def reversal(mock_http_client, mock_token_manager):
     """Fixture to create a Reversal instance with mocked dependencies."""
     return Reversal(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def valid_reversal_request():
     """Create a valid ReversalRequest for testing."""
@@ -54,7 +34,6 @@ def valid_reversal_request():
         Remarks="Test",
         Occasion="work",
     )
-
 
 def test_reverse_request_acknowledged(reversal, mock_http_client):
     """Test that reversal request is acknowledged, not finalized."""
@@ -80,7 +59,6 @@ def test_reverse_request_acknowledged(reversal, mock_http_client):
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 def test_reverse_http_error(reversal, mock_http_client):
     """Test handling of HTTP errors during reversal request."""
     request = valid_reversal_request()
@@ -88,7 +66,6 @@ def test_reverse_http_error(reversal, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         reversal.reverse(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_reversal_result_callback_success():
     """Test parsing of a successful reversal result callback."""
@@ -120,13 +97,11 @@ def test_reversal_result_callback_success():
     assert callback.Result.TransactionID == "MJ561H6X5O"
     assert callback.Result.ResultParameters.ResultParameter[0].Key == "Amount"
 
-
 def test_reversal_result_callback_response():
     """Test the response schema for result callback."""
     resp = ReversalResultCallbackResponse()
     assert resp.ResultCode == 0
     assert "processed successfully" in resp.ResultDesc
-
 
 def test_reversal_timeout_callback():
     """Test parsing of a reversal timeout callback."""
@@ -144,13 +119,11 @@ def test_reversal_timeout_callback():
     assert callback.Result.ResultCode == "1"
     assert "timed out" in callback.Result.ResultDesc
 
-
 def test_reversal_timeout_callback_response():
     """Test the response schema for timeout callback."""
     resp = ReversalTimeoutCallbackResponse()
     assert resp.ResultCode == 0
     assert "Timeout notification received" in resp.ResultDesc
-
 
 def test_reversal_request_identifier_type_is_valid():
     """Test that invalid ReceiverIdentifierType raises ValueError."""
@@ -167,7 +140,6 @@ def test_reversal_request_identifier_type_is_valid():
     request = ReversalRequest(**kwargs)
     assert request.RecieverIdentifierType == "11"
 
-
 def test_reversal_request_remarks_too_long_raises():
     """Test that Remarks exceeding length raises ValueError."""
     kwargs = dict(
@@ -183,7 +155,6 @@ def test_reversal_request_remarks_too_long_raises():
     with pytest.raises(ValueError) as excinfo:
         ReversalRequest(**kwargs)
     assert "Remarks must not exceed 100 characters." in str(excinfo.value)
-
 
 def test_reversal_request_occasion_too_long_raises():
     """Test that Occasion exceeding length raises ValueError."""
@@ -202,7 +173,6 @@ def test_reversal_request_occasion_too_long_raises():
         ReversalRequest(**kwargs)
     assert "Occasion must not exceed 100 characters." in str(excinfo.value)
 
-
 def test_reverse_responsecode_string_no_type_error(reversal, mock_http_client):
     """Ensure is_successful handles ResponseCode as a string without TypeError."""
     request = valid_reversal_request()
@@ -219,7 +189,6 @@ def test_reverse_responsecode_string_no_type_error(reversal, mock_http_client):
     assert isinstance(response, ReversalResponse)
     # Calling is_successful should not raise a TypeError when comparing str to int
     assert response.is_successful() is True
-
 
 def test_reversal_result_callback_success_is_successful():
     """Test is_successful method for a successful reversal result callback."""
@@ -247,7 +216,6 @@ def test_reversal_result_callback_success_is_successful():
     callback = ReversalResultCallback(**payload)
     assert callback.is_successful() is True
 
-
 def test_reversal_result_callback_failure_is_successful():
     """Test is_successful method for a failure reversal result callback."""
     payload = {
@@ -274,7 +242,6 @@ def test_reversal_result_callback_failure_is_successful():
     callback = ReversalResultCallback(**payload)
     assert callback.is_successful() is False
 
-
 def test_reversal_result_callback_success_code_is_successful():
     """Test is_successful method with a success code as a string."""
     payload = {
@@ -289,7 +256,6 @@ def test_reversal_result_callback_success_code_is_successful():
     }
     callback = ReversalResultCallback(**payload)
     assert callback.is_successful() is True
-
 
 def test_reversal_result_callback_failure_code_is_successful():
     """Test is_successful method with a failure code."""
@@ -306,28 +272,12 @@ def test_reversal_result_callback_failure_code_is_successful():
     callback = ReversalResultCallback(**payload)
     assert callback.is_successful() is False
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token_async"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_reversal(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncReversal instance with mocked dependencies."""
     return AsyncReversal(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_reverse_request_acknowledged(
@@ -349,7 +299,6 @@ async def test_async_reverse_request_acknowledged(
     assert response.is_successful() is True
     assert response.ConversationID == response_data["ConversationID"]
 
-
 @pytest.mark.asyncio
 async def test_async_reverse_http_error(async_reversal, mock_async_http_client):
     """Test handling of HTTP errors during async reversal request."""
@@ -358,7 +307,6 @@ async def test_async_reverse_http_error(async_reversal, mock_async_http_client):
     with pytest.raises(Exception) as excinfo:
         await async_reversal.reverse(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_reverse_token_manager_called(
@@ -377,7 +325,6 @@ async def test_async_reverse_token_manager_called(
     await async_reversal.reverse(request)
 
     mock_async_token_manager.get_token.assert_awaited_once()
-
 
 @pytest.mark.asyncio
 async def test_async_reverse_http_client_post_called(
@@ -399,9 +346,8 @@ async def test_async_reverse_http_client_post_called(
     call_args = mock_async_http_client.post.call_args
     assert call_args[0][0] == "/mpesa/reversal/v1/request"
     assert "Authorization" in call_args[1]["headers"]
-    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token_async"
+    assert call_args[1]["headers"]["Authorization"] == "Bearer test_token"
     assert call_args[1]["headers"]["Content-Type"] == "application/json"
-
 
 @pytest.mark.asyncio
 async def test_async_reverse_responsecode_string_no_type_error(

--- a/tests/unit/services/test_b2b_service.py
+++ b/tests/unit/services/test_b2b_service.py
@@ -1,7 +1,6 @@
 """Unit tests for B2BService class."""
 
 import pytest
-from unittest.mock import MagicMock
 
 from mpesakit.services.b2b import B2BService, AsyncB2BService
 from mpesakit.business_buy_goods import (
@@ -13,36 +12,6 @@ from mpesakit.business_paybill import (
 from mpesakit.b2b_express_checkout import (
     B2BExpressCheckoutResponse,
 )
-from mpesakit.auth import TokenManager, AsyncTokenManager
-from mpesakit.http_client import HttpClient, AsyncHttpClient
-from unittest.mock import AsyncMock
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "async_test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
 
 @pytest.fixture
 def b2b_service(mock_http_client, mock_token_manager):
@@ -52,7 +21,6 @@ def b2b_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_express_checkout_calls_ussd_push(b2b_service, mock_http_client):
     """Test that express_checkout calls the B2BExpressCheckout service."""
@@ -71,7 +39,6 @@ def test_express_checkout_calls_ussd_push(b2b_service, mock_http_client):
     assert isinstance(resp, B2BExpressCheckoutResponse)
     assert resp.code == "0"
     assert resp.status == "USSD Initiated Successfully"
-
 
 def test_paybill_calls_paybill(b2b_service, mock_http_client):
     """Test that paybill calls the BusinessPayBill service."""
@@ -98,7 +65,6 @@ def test_paybill_calls_paybill(b2b_service, mock_http_client):
     assert isinstance(resp, BusinessPayBillResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
-
 
 def test_buygoods_calls_buy_goods(b2b_service, mock_http_client):
     """Test that buygoods calls the BusinessBuyGoods service."""
@@ -127,7 +93,6 @@ def test_buygoods_calls_buy_goods(b2b_service, mock_http_client):
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
 
-
 def test_express_checkout_filters_kwargs(b2b_service, mock_http_client):
     """Test that express_checkout filters out unexpected kwargs."""
     response_data = {"code": "0", "status": "USSD Initiated Successfully"}
@@ -147,7 +112,6 @@ def test_express_checkout_filters_kwargs(b2b_service, mock_http_client):
     assert isinstance(resp, B2BExpressCheckoutResponse)
     assert resp.is_successful() is True
     assert resp.status == "USSD Initiated Successfully"
-
 
 def test_b2b_service_initializes_services_correctly(
     mock_http_client, mock_token_manager
@@ -178,7 +142,6 @@ def async_b2b_service(mock_async_http_client, mock_async_token_manager):
         token_manager=mock_async_token_manager
     )
 
-
 @pytest.mark.asyncio
 async def test_async_express_checkout_calls_ussd_push(
     async_b2b_service, mock_async_http_client
@@ -200,7 +163,6 @@ async def test_async_express_checkout_calls_ussd_push(
     assert isinstance(resp, B2BExpressCheckoutResponse)
     assert resp.code == "0"
     assert resp.status == "USSD Initiated Successfully"
-
 
 @pytest.mark.asyncio
 async def test_async_paybill_calls_paybill(async_b2b_service, mock_async_http_client):
@@ -229,7 +191,6 @@ async def test_async_paybill_calls_paybill(async_b2b_service, mock_async_http_cl
     assert isinstance(resp, BusinessPayBillResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
-
 
 @pytest.mark.asyncio
 async def test_async_buygoods_calls_buy_goods(
@@ -262,7 +223,6 @@ async def test_async_buygoods_calls_buy_goods(
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
 
-
 @pytest.mark.asyncio
 async def test_async_express_checkout_filters_kwargs(
     async_b2b_service, mock_async_http_client
@@ -285,7 +245,6 @@ async def test_async_express_checkout_filters_kwargs(
     assert isinstance(resp, B2BExpressCheckoutResponse)
     assert resp.is_successful() is True
     assert resp.status == "USSD Initiated Successfully"
-
 
 def test_async_b2b_service_initializes_services_correctly(
     mock_async_http_client, mock_async_token_manager

--- a/tests/unit/services/test_b2c_service.py
+++ b/tests/unit/services/test_b2c_service.py
@@ -1,44 +1,12 @@
 """Unit tests for B2CService class."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 from mpesakit.services.b2c import B2CService, AsyncB2CService
 from mpesakit.b2c import B2CResponse, B2CCommandIDType
-from mpesakit.auth import TokenManager, AsyncTokenManager
-from mpesakit.http_client import HttpClient, AsyncHttpClient
 
 from mpesakit.b2c_account_top_up import (
     B2CAccountTopUpResponse,
 )
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "async_test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
 
 @pytest.fixture
 def b2c_service(mock_http_client, mock_token_manager):
@@ -48,7 +16,6 @@ def b2c_service(mock_http_client, mock_token_manager):
         token_manager=mock_token_manager,
     )
 
-
 @pytest.fixture
 def async_b2c_service(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncB2CService instance with mocked dependencies."""
@@ -56,7 +23,6 @@ def async_b2c_service(mock_async_http_client, mock_async_token_manager):
         http_client=mock_async_http_client,
         token_manager=mock_async_token_manager,
     )
-
 
 def test_send_payment_calls_b2c_send_payment(b2c_service, mock_http_client):
     """Test that send_payment calls the B2C service."""
@@ -85,7 +51,6 @@ def test_send_payment_calls_b2c_send_payment(b2c_service, mock_http_client):
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "Request accepted successfully."
 
-
 def test_account_topup_calls_account_topup(b2c_service, mock_http_client):
     """Test that account_topup calls the B2CAccountTopUp service."""
     response_data = {
@@ -111,7 +76,6 @@ def test_account_topup_calls_account_topup(b2c_service, mock_http_client):
     assert isinstance(resp, B2CAccountTopUpResponse)
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "TopUp accepted successfully."
-
 
 def test_send_payment_filters_kwargs(b2c_service, mock_http_client):
     """Test that send_payment filters out unexpected kwargs."""
@@ -140,7 +104,6 @@ def test_send_payment_filters_kwargs(b2c_service, mock_http_client):
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "Request accepted successfully."
 
-
 def test_account_topup_filters_kwargs(b2c_service, mock_http_client):
     """Test that account_topup filters out unexpected kwargs."""
     response_data = {
@@ -167,7 +130,6 @@ def test_account_topup_filters_kwargs(b2c_service, mock_http_client):
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "TopUp accepted successfully."
 
-
 def test_b2c_service_initializes_b2c_correctly(mock_http_client, mock_token_manager):
     """Test B2CService initializes with correct arguments."""
     service = B2CService(
@@ -180,7 +142,6 @@ def test_b2c_service_initializes_b2c_correctly(mock_http_client, mock_token_mana
     if hasattr(service, "b2c"):
         assert service.b2c.http_client is mock_http_client
         assert service.b2c.token_manager is mock_token_manager
-
 
 @pytest.mark.asyncio
 async def test_async_send_payment_calls_b2c_send_payment(
@@ -212,7 +173,6 @@ async def test_async_send_payment_calls_b2c_send_payment(
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "Request accepted successfully."
 
-
 @pytest.mark.asyncio
 async def test_async_account_topup_calls_account_topup(
     async_b2c_service, mock_async_http_client
@@ -241,7 +201,6 @@ async def test_async_account_topup_calls_account_topup(
     assert isinstance(resp, B2CAccountTopUpResponse)
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "TopUp accepted successfully."
-
 
 @pytest.mark.asyncio
 async def test_async_send_payment_filters_kwargs(
@@ -274,7 +233,6 @@ async def test_async_send_payment_filters_kwargs(
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "Request accepted successfully."
 
-
 @pytest.mark.asyncio
 async def test_async_account_topup_filters_kwargs(
     async_b2c_service, mock_async_http_client
@@ -304,7 +262,6 @@ async def test_async_account_topup_filters_kwargs(
     assert isinstance(resp, B2CAccountTopUpResponse)
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "TopUp accepted successfully."
-
 
 def test_async_b2c_service_initializes_b2c_correctly(
     mock_async_http_client, mock_async_token_manager

--- a/tests/unit/services/test_balance_service.py
+++ b/tests/unit/services/test_balance_service.py
@@ -1,10 +1,10 @@
 """Unit tests for BalanceService class."""
 
 import pytest
-from unittest.mock import MagicMock
-from mpesakit.services.balance import BalanceService
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
+from unittest.mock import AsyncMock, MagicMock
+from mpesakit.services.balance import BalanceService, AsyncBalanceService
+from mpesakit.auth import TokenManager, AsyncTokenManager
+from mpesakit.http_client import HttpClient, AsyncHttpClient
 from mpesakit.account_balance import (
     AccountBalanceResponse,
 )
@@ -25,11 +25,34 @@ def mock_http_client():
 
 
 @pytest.fixture
+def mock_async_token_manager():
+    """Mock AsyncTokenManager to return a fixed token."""
+    mock = AsyncMock(spec=AsyncTokenManager)
+    mock.get_token.return_value = "async_test_token"
+    return mock
+
+
+@pytest.fixture
+def mock_async_http_client():
+    """Mock AsyncHttpClient to simulate async HTTP requests."""
+    return AsyncMock(spec=AsyncHttpClient)
+
+
+@pytest.fixture
 def balance_service(mock_http_client, mock_token_manager):
     """Fixture to create a BalanceService instance with mocked dependencies."""
     return BalanceService(
         http_client=mock_http_client,
         token_manager=mock_token_manager,
+    )
+
+
+@pytest.fixture
+def async_balance_service(mock_async_http_client, mock_async_token_manager):
+    """Fixture to create an AsyncBalanceService instance with mocked dependencies."""
+    return AsyncBalanceService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
     )
 
 
@@ -103,3 +126,78 @@ def test_balance_service_initializes_account_balance_correctly(
     assert service.token_manager is mock_token_manager
     assert service.account_balance.http_client is mock_http_client
     assert service.account_balance.token_manager is mock_token_manager
+
+
+def test_async_init_sets_account_balance(async_balance_service):
+    """Test that AsyncBalanceService initializes AsyncAccountBalance."""
+    assert hasattr(async_balance_service, "account_balance")
+
+
+@pytest.mark.asyncio
+async def test_async_query_calls_account_balance_query(
+    async_balance_service, mock_async_http_client
+):
+    """Test that async query returns AccountBalanceResponse."""
+    response_data = {
+        "OriginatorConversationID": "515-5258779-3",
+        "ConversationID": "AG_20200123_0000417fed8ed666e976",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_balance_service.query(
+        initiator="apiuser",
+        security_credential="secure",
+        command_id="AccountBalance",
+        party_a=600100,
+        identifier_type=4,
+        remarks="Balance inquiry",
+        result_url="http://result.url",
+        queue_timeout_url="http://timeout.url",
+    )
+    assert isinstance(resp, AccountBalanceResponse)
+    assert resp.is_successful() is True
+    assert "request successfully" in resp.ResponseDescription
+
+
+@pytest.mark.asyncio
+async def test_async_query_filters_kwargs(
+    async_balance_service, mock_async_http_client
+):
+    """Test that async query filters out unexpected kwargs."""
+    response_data = {
+        "OriginatorConversationID": "515-5258779-3",
+        "ConversationID": "AG_20200123_0000417fed8ed666e976",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_balance_service.query(
+        initiator="apiuser",
+        security_credential="secure",
+        command_id="AccountBalance",
+        party_a=600100,
+        identifier_type=4,
+        remarks="Balance inquiry",
+        result_url="http://result.url",
+        queue_timeout_url="http://timeout.url",
+        unexpected_field="should_be_filtered",
+    )
+    assert isinstance(resp, AccountBalanceResponse)
+    assert hasattr(resp, "unexpected_field") is False
+
+
+def test_async_balance_service_initializes_account_balance_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncBalanceService initializes with correct arguments."""
+    service = AsyncBalanceService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.account_balance.http_client is mock_async_http_client
+    assert service.account_balance.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_balance_service.py
+++ b/tests/unit/services/test_balance_service.py
@@ -1,42 +1,10 @@
 """Unit tests for BalanceService class."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 from mpesakit.services.balance import BalanceService, AsyncBalanceService
-from mpesakit.auth import TokenManager, AsyncTokenManager
-from mpesakit.http_client import HttpClient, AsyncHttpClient
 from mpesakit.account_balance import (
     AccountBalanceResponse,
 )
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "async_test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
 
 @pytest.fixture
 def balance_service(mock_http_client, mock_token_manager):
@@ -46,7 +14,6 @@ def balance_service(mock_http_client, mock_token_manager):
         token_manager=mock_token_manager,
     )
 
-
 @pytest.fixture
 def async_balance_service(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncBalanceService instance with mocked dependencies."""
@@ -55,11 +22,9 @@ def async_balance_service(mock_async_http_client, mock_async_token_manager):
         token_manager=mock_async_token_manager,
     )
 
-
 def test_init_sets_account_balance(balance_service):
     """Test that BalanceService initializes AccountBalance."""
     assert hasattr(balance_service, "account_balance")
-
 
 def test_query_calls_account_balance_query(balance_service, mock_http_client):
     """Test that query calls the BalanceService and returns AccountBalanceResponse."""
@@ -84,7 +49,6 @@ def test_query_calls_account_balance_query(balance_service, mock_http_client):
     assert isinstance(resp, AccountBalanceResponse)
     assert resp.is_successful() is True
     assert "request successfully" in resp.ResponseDescription
-
 
 def test_query_filters_kwargs(balance_service, mock_http_client):
     """Test that query filters out unexpected kwargs."""
@@ -113,7 +77,6 @@ def test_query_filters_kwargs(balance_service, mock_http_client):
         hasattr(resp, "unexpected_field") is False
     )  # Response should not have ExtraField
 
-
 def test_balance_service_initializes_account_balance_correctly(
     mock_http_client, mock_token_manager
 ):
@@ -127,11 +90,9 @@ def test_balance_service_initializes_account_balance_correctly(
     assert service.account_balance.http_client is mock_http_client
     assert service.account_balance.token_manager is mock_token_manager
 
-
 def test_async_init_sets_account_balance(async_balance_service):
     """Test that AsyncBalanceService initializes AsyncAccountBalance."""
     assert hasattr(async_balance_service, "account_balance")
-
 
 @pytest.mark.asyncio
 async def test_async_query_calls_account_balance_query(
@@ -160,7 +121,6 @@ async def test_async_query_calls_account_balance_query(
     assert resp.is_successful() is True
     assert "request successfully" in resp.ResponseDescription
 
-
 @pytest.mark.asyncio
 async def test_async_query_filters_kwargs(
     async_balance_service, mock_async_http_client
@@ -187,7 +147,6 @@ async def test_async_query_filters_kwargs(
     )
     assert isinstance(resp, AccountBalanceResponse)
     assert hasattr(resp, "unexpected_field") is False
-
 
 def test_async_balance_service_initializes_account_balance_correctly(
     mock_async_http_client, mock_async_token_manager

--- a/tests/unit/services/test_bill_service.py
+++ b/tests/unit/services/test_bill_service.py
@@ -3,8 +3,6 @@
 import pytest
 from unittest.mock import MagicMock
 from mpesakit.services.bill import BillService
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
 
 from mpesakit.bill_manager import (
     BillManagerOptInResponse,
@@ -16,21 +14,6 @@ from mpesakit.bill_manager import (
     InvoiceItem,
 )
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def bill_service(mock_http_client, mock_token_manager):
     """Fixture to create a BillService instance with mocked dependencies."""
@@ -38,7 +21,6 @@ def bill_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 @pytest.fixture
 def bill_service_with_app_key(mock_http_client, mock_token_manager):
@@ -48,7 +30,6 @@ def bill_service_with_app_key(mock_http_client, mock_token_manager):
         token_manager=mock_token_manager,
         app_key="test_app_key",
     )
-
 
 def test_opt_in_calls_bill_manager_opt_in(bill_service, mock_http_client):
     """Test opt_in calls BillManager.opt_in."""
@@ -71,7 +52,6 @@ def test_opt_in_calls_bill_manager_opt_in(bill_service, mock_http_client):
     assert isinstance(resp, BillManagerOptInResponse)
     resp.is_successful() is True
 
-
 def test_bill_manager_update_opt_in(bill_service_with_app_key, mock_http_client):
     """Test update_opt_in calls BillManager.update_opt_in."""
     response_data = {
@@ -90,7 +70,6 @@ def test_bill_manager_update_opt_in(bill_service_with_app_key, mock_http_client)
     )
     assert isinstance(resp, BillManagerUpdateOptInResponse)
     assert resp.is_successful() is True
-
 
 def test_bill_manager_send_single_invoice(
     bill_service_with_app_key,
@@ -121,7 +100,6 @@ def test_bill_manager_send_single_invoice(
     assert isinstance(resp, BillManagerSingleInvoiceResponse)
     assert resp.is_successful() is True
 
-
 def test_bill_manager_send_bulk_invoice(bill_service_with_app_key, mock_http_client):
     """Test send_bulk_invoice calls BillManager.send_bulk_invoice."""
     response_data = {
@@ -137,7 +115,6 @@ def test_bill_manager_send_bulk_invoice(bill_service_with_app_key, mock_http_cli
 
     assert isinstance(resp, BillManagerBulkInvoiceResponse)
     assert resp.is_successful() is True
-
 
 def test_bill_manager_cancel_single_invoice(
     bill_service_with_app_key,
@@ -156,7 +133,6 @@ def test_bill_manager_cancel_single_invoice(
     assert isinstance(resp, BillManagerCancelInvoiceResponse)
     assert resp.is_successful() is True
 
-
 def test_bill_manager_cancel_bulk_invoice(bill_service_with_app_key, mock_http_client):
     """Test cancel_bulk_invoice calls BillManager.cancel_bulk_invoice."""
     response_data = {
@@ -172,7 +148,6 @@ def test_bill_manager_cancel_bulk_invoice(bill_service_with_app_key, mock_http_c
 
     assert isinstance(resp, BillManagerCancelInvoiceResponse)
     assert resp.is_successful() is True
-
 
 def test_bill_service_initializes_bill_manager_correctly(
     mock_http_client, mock_token_manager

--- a/tests/unit/services/test_c2b_service.py
+++ b/tests/unit/services/test_c2b_service.py
@@ -1,26 +1,8 @@
 """Unit tests for the C2BService class in mpesakit.services.c2b module."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.c2b import C2BService
 from mpesakit.c2b import C2BRegisterUrlResponse, C2BResponseType
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Creates a mock TokenManager."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Creates a mock HttpClient."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def c2b_service(mock_http_client, mock_token_manager):
@@ -29,7 +11,6 @@ def c2b_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_register_url_success(c2b_service, mock_http_client):
     """Test successful registration of C2B URLs."""
@@ -51,7 +32,6 @@ def test_register_url_success(c2b_service, mock_http_client):
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "URLs registered successfully."
 
-
 def test_register_url_filters_kwargs(c2b_service, mock_http_client):
     """Test that extra kwargs are filtered out in the request."""
     response_data = {
@@ -72,7 +52,6 @@ def test_register_url_filters_kwargs(c2b_service, mock_http_client):
     assert isinstance(resp, C2BRegisterUrlResponse)
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "URLs registered successfully."
-
 
 def test_c2b_service_initializes_correctly(mock_http_client, mock_token_manager):
     """Test C2BService initializes with correct arguments."""

--- a/tests/unit/services/test_dynamic_qr_service.py
+++ b/tests/unit/services/test_dynamic_qr_service.py
@@ -1,29 +1,11 @@
 """Unit tests for the DynamicQRCodeService class in mpesakit.services.dynamic_qr module."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.dynamic_qr import DynamicQRCodeService
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
 from mpesakit.dynamic_qr_code import (
     DynamicQRGenerateResponse,
     DynamicQRTransactionType,
 )
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Creates a mock TokenManager."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Creates a mock HttpClient."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def dynamic_qr_service(mock_http_client, mock_token_manager):
@@ -32,7 +14,6 @@ def dynamic_qr_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_generate_success(dynamic_qr_service, mock_http_client):
     """Test successful generation of a dynamic QR code."""
@@ -55,7 +36,6 @@ def test_generate_success(dynamic_qr_service, mock_http_client):
     )
     assert isinstance(resp, DynamicQRGenerateResponse)
     assert resp.is_successful() is True
-
 
 def test_generate_filters_kwargs(dynamic_qr_service, mock_http_client):
     """Test that extra kwargs are filtered out in the request."""
@@ -83,7 +63,6 @@ def test_generate_filters_kwargs(dynamic_qr_service, mock_http_client):
     )
     assert isinstance(resp, DynamicQRGenerateResponse)
     assert resp.is_successful() is True
-
 
 def test_dynamic_qr_service_initializes_correctly(mock_http_client, mock_token_manager):
     """Test DynamicQRCodeService initializes with correct arguments."""

--- a/tests/unit/services/test_express_service.py
+++ b/tests/unit/services/test_express_service.py
@@ -1,31 +1,13 @@
 """Unit tests for the StkPushService facade in mpesakit.services.express module."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.express import StkPushService
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
 
 from mpesakit.mpesa_express import (
     StkPushSimulateResponse,
     StkPushQueryResponse,
     TransactionType,
 )
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Creates a mock TokenManager."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Creates a mock HttpClient."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def stk_push_service(mock_http_client, mock_token_manager):
@@ -36,7 +18,6 @@ def stk_push_service(mock_http_client, mock_token_manager):
         token_manager=mock_token_manager,
     )
     return service
-
 
 def test_push_success(stk_push_service, mock_http_client):
     """Test successful STK Push transaction."""
@@ -64,7 +45,6 @@ def test_push_success(stk_push_service, mock_http_client):
 
     assert isinstance(resp, StkPushSimulateResponse)
     assert resp.is_successful() is True
-
 
 def test_push_filters_kwargs(stk_push_service, mock_http_client):
     """Test that extra kwargs are filtered out in push."""
@@ -94,7 +74,6 @@ def test_push_filters_kwargs(stk_push_service, mock_http_client):
     assert isinstance(resp, StkPushSimulateResponse)
     assert not hasattr(resp, "ExtraField")
 
-
 def test_query_success(stk_push_service, mock_http_client):
     """Test successful STK Push query."""
     response = {
@@ -114,7 +93,6 @@ def test_query_success(stk_push_service, mock_http_client):
     )
     assert isinstance(resp, StkPushQueryResponse)
     assert resp.is_successful() is True
-
 
 def test_query_filters_kwargs(stk_push_service, mock_http_client):
     """Test that extra kwargs are filtered out in query."""
@@ -137,7 +115,6 @@ def test_query_filters_kwargs(stk_push_service, mock_http_client):
     assert isinstance(resp, StkPushQueryResponse)
     resp.is_successful() is True
     assert not hasattr(resp, "ExtraField")
-
 
 def test_stk_push_service_initializes_stk_push_correctly(
     mock_http_client, mock_token_manager

--- a/tests/unit/services/test_ratiba_service.py
+++ b/tests/unit/services/test_ratiba_service.py
@@ -1,31 +1,13 @@
 """Unit tests for the RatibaService facade in mpesakit.services.ratiba module."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.ratiba import RatibaService
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
 from mpesakit.mpesa_ratiba import (
     StandingOrderResponse,
     TransactionTypeEnum,
     ReceiverPartyIdentifierTypeEnum,
     FrequencyEnum,
 )
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Creates a mock TokenManager."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Creates a mock HttpClient."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def ratiba_service(mock_http_client, mock_token_manager):
@@ -34,7 +16,6 @@ def ratiba_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_create_standing_order_success(ratiba_service, mock_http_client):
     """Test successful Standing Order creation."""
@@ -69,7 +50,6 @@ def test_create_standing_order_success(ratiba_service, mock_http_client):
 
     assert isinstance(resp, StandingOrderResponse)
     assert resp.is_successful() is True
-
 
 def test_create_standing_order_filters_kwargs(ratiba_service, mock_http_client):
     """Test that extra kwargs are filtered out in create_standing_order."""
@@ -106,7 +86,6 @@ def test_create_standing_order_filters_kwargs(ratiba_service, mock_http_client):
     assert isinstance(resp, StandingOrderResponse)
     assert resp.is_successful() is True
     assert not hasattr(resp, "ExtraField")
-
 
 def test_ratiba_service_initializes_ratiba_correctly(
     mock_http_client, mock_token_manager

--- a/tests/unit/services/test_reversal_service.py
+++ b/tests/unit/services/test_reversal_service.py
@@ -1,26 +1,8 @@
 """Unit tests for ReversalService class."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.reversal import ReversalService
 from mpesakit.reversal import ReversalResponse
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def reversal_service(mock_http_client, mock_token_manager):
@@ -29,7 +11,6 @@ def reversal_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_reverse_calls_reversal(reversal_service, mock_http_client):
     """Test that reverse calls the Reversal.reverse method with correct request."""
@@ -55,7 +36,6 @@ def test_reverse_calls_reversal(reversal_service, mock_http_client):
     assert isinstance(resp, ReversalResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
-
 
 def test_reverse_filters_kwargs(reversal_service, mock_http_client):
     """Test that reverse filters out unexpected kwargs."""
@@ -84,7 +64,6 @@ def test_reverse_filters_kwargs(reversal_service, mock_http_client):
 
     # unexpected_field should not be present
     assert not hasattr(resp, "unexpected_field")
-
 
 def test_reversal_service_initializes_reversal_correctly(
     mock_http_client, mock_token_manager

--- a/tests/unit/services/test_tax_service.py
+++ b/tests/unit/services/test_tax_service.py
@@ -1,26 +1,8 @@
 """Unit tests for TaxService class."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.tax import TaxService
 from mpesakit.tax_remittance import TaxRemittanceResponse
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def tax_service(mock_http_client, mock_token_manager):
@@ -29,7 +11,6 @@ def tax_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_remittance_calls_tax_remittance(tax_service, mock_http_client):
     """Test that remittance calls TaxRemittance.remittance with correct request."""
@@ -54,7 +35,6 @@ def test_remittance_calls_tax_remittance(tax_service, mock_http_client):
     assert isinstance(resp, TaxRemittanceResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
-
 
 def test_remittance_filters_kwargs(tax_service, mock_http_client):
     """Test that remittance filters out unexpected kwargs."""
@@ -81,7 +61,6 @@ def test_remittance_filters_kwargs(tax_service, mock_http_client):
     assert resp.is_successful() is True
     # unexpected_field should not be present in the response
     assert not hasattr(resp, "unexpected_field")
-
 
 def test_tax_service_initializes_tax_correctly(mock_http_client, mock_token_manager):
     """Test TaxService initializes with correct http_client and token_manager."""

--- a/tests/unit/services/test_transaction_service.py
+++ b/tests/unit/services/test_transaction_service.py
@@ -1,26 +1,8 @@
 """Unit tests for TransactionService class."""
 
 import pytest
-from unittest.mock import MagicMock
 from mpesakit.services.transaction import TransactionService
 from mpesakit.transaction_status import TransactionStatusResponse
-from mpesakit.auth import TokenManager
-from mpesakit.http_client import HttpClient
-
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
 
 @pytest.fixture
 def transaction_service(mock_http_client, mock_token_manager):
@@ -29,7 +11,6 @@ def transaction_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
-
 
 def test_query_status_calls_transaction_status(transaction_service, mock_http_client):
     """Test that query_status calls TransactionStatus.query with correct request."""
@@ -95,7 +76,6 @@ def test_query_status_default_remarks(transaction_service, mock_http_client):
     }
     mock_http_client.post.return_value = response_data
 
-
     resp = transaction_service.query_status(
         initiator="testapi",
         security_credential="encrypted_credential",
@@ -113,7 +93,6 @@ def test_query_status_default_remarks(transaction_service, mock_http_client):
     assert isinstance(resp, TransactionStatusResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
-
 
 def test_query_status_filters_kwargs(transaction_service, mock_http_client):
     """Test that query_status filters out unexpected kwargs."""
@@ -142,7 +121,6 @@ def test_query_status_filters_kwargs(transaction_service, mock_http_client):
     assert resp.is_successful() is True
     # unexpected_field should not be present in the response
     assert not hasattr(resp, "unexpected_field")
-
 
 def test_transaction_service_initializes_correctly(
     mock_http_client, mock_token_manager

--- a/tests/unit/tax_remittance/test_tax_remittance.py
+++ b/tests/unit/tax_remittance/test_tax_remittance.py
@@ -4,12 +4,8 @@ This module tests the Tax Remittance API client, ensuring it can handle remittan
 process responses correctly, and manage error cases.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
 from mpesakit.tax_remittance import (
     TaxRemittanceRequest,
     TaxRemittanceResponse,
@@ -20,26 +16,10 @@ from mpesakit.tax_remittance import (
 )
 from mpesakit.tax_remittance.tax_remittance import AsyncTaxRemittance, TaxRemittance
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager to return a fixed token."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient to simulate HTTP requests."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def tax_remittance(mock_http_client, mock_token_manager):
     """Fixture to create a TaxRemittance instance with mocked dependencies."""
     return TaxRemittance(http_client=mock_http_client, token_manager=mock_token_manager)
-
 
 def valid_tax_remittance_request():
     """Create a valid TaxRemittanceRequest for testing."""
@@ -53,7 +33,6 @@ def valid_tax_remittance_request():
         QueueTimeOutURL="https://mydomain.com/b2b/remittax/queue/",
         ResultURL="https://mydomain.com/b2b/remittax/result/",
     )
-
 
 def test_remittance_request_acknowledged(tax_remittance, mock_http_client):
     """Test that remittance request is acknowledged, not finalized."""
@@ -77,7 +56,6 @@ def test_remittance_request_acknowledged(tax_remittance, mock_http_client):
     assert response.ResponseCode == response_data["ResponseCode"]
     assert response.ResponseDescription == response_data["ResponseDescription"]
 
-
 def test_remittance_http_error(tax_remittance, mock_http_client):
     """Test handling of HTTP errors during remittance request."""
     request = valid_tax_remittance_request()
@@ -85,7 +63,6 @@ def test_remittance_http_error(tax_remittance, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         tax_remittance.remittance(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_tax_remittance_result_callback_success():
     """Test parsing of a successful tax remittance result callback."""
@@ -115,13 +92,11 @@ def test_tax_remittance_result_callback_success():
     assert callback.Result.TransactionID == "QKA81LK5CY"
     assert callback.Result.ResultParameters.ResultParameter[0].Key == "Amount"
 
-
 def test_tax_remittance_result_callback_response():
     """Test the response schema for result callback."""
     resp = TaxRemittanceResultCallbackResponse()
     assert resp.ResultCode == 0
     assert "Callback received successfully" in resp.ResultDesc
-
 
 def test_tax_remittance_timeout_callback():
     """Test parsing of a tax remittance timeout callback."""
@@ -139,13 +114,11 @@ def test_tax_remittance_timeout_callback():
     assert callback.Result.ResultCode == 1
     assert "timed out" in callback.Result.ResultDesc
 
-
 def test_tax_remittance_timeout_callback_response():
     """Test the response schema for timeout callback."""
     resp = TaxRemittanceTimeoutCallbackResponse()
     assert resp.ResultCode == 0
     assert "Timeout notification received" in resp.ResultDesc
-
 
 def test_tax_remittance_result_callback_with_string_resultcode():
     """Ensure is_successful handles ResultCode provided as a string without type errors."""
@@ -169,28 +142,12 @@ def test_tax_remittance_result_callback_with_string_resultcode():
     # Should not raise a TypeError comparing str and int; should treat "0" as success
     assert callback.is_successful() is True
 
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
-
 @pytest.fixture
 def async_tax_remittance(mock_async_http_client, mock_async_token_manager):
     """Fixture to create an AsyncTaxRemittance instance with mocked dependencies."""
     return AsyncTaxRemittance(
         http_client=mock_async_http_client, token_manager=mock_async_token_manager
     )
-
 
 @pytest.mark.asyncio
 async def test_async_remittance_request_acknowledged(
@@ -212,7 +169,6 @@ async def test_async_remittance_request_acknowledged(
     assert response.is_successful() is True
     assert response.ConversationID == response_data["ConversationID"]
 
-
 @pytest.mark.asyncio
 async def test_async_remittance_http_error(
     async_tax_remittance, mock_async_http_client
@@ -223,7 +179,6 @@ async def test_async_remittance_http_error(
     with pytest.raises(Exception) as excinfo:
         await async_tax_remittance.remittance(request)
     assert "Async HTTP error" in str(excinfo.value)
-
 
 @pytest.mark.asyncio
 async def test_async_remittance_token_retrieval(

--- a/tests/unit/transaction_status/test_transaction_status.py
+++ b/tests/unit/transaction_status/test_transaction_status.py
@@ -3,12 +3,8 @@
 This module tests the TransactionStatus class and its methods for querying transaction status.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
-from mpesakit.auth import AsyncTokenManager, TokenManager
-from mpesakit.http_client import AsyncHttpClient, HttpClient
 from mpesakit.transaction_status import (
     AsyncTransactionStatus,
     TransactionStatus,
@@ -20,28 +16,12 @@ from mpesakit.transaction_status import (
     TransactionStatusResultParameter,
 )
 
-
-@pytest.fixture
-def mock_token_manager():
-    """Mock TokenManager for testing."""
-    mock = MagicMock(spec=TokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_http_client():
-    """Mock HttpClient for testing."""
-    return MagicMock(spec=HttpClient)
-
-
 @pytest.fixture
 def transaction_status(mock_http_client, mock_token_manager):
     """Fixture to create a TransactionStatus instance with mocked dependencies."""
     return TransactionStatus(
         http_client=mock_http_client, token_manager=mock_token_manager
     )
-
 
 def valid_transaction_status_request():
     """Create a valid TransactionStatusRequest for testing."""
@@ -58,7 +38,6 @@ def valid_transaction_status_request():
         Occasion="JuneSalary",
         OriginalConversationID=None,
     )
-
 
 def test_query_success(transaction_status, mock_http_client):
     """Test querying transaction status with a valid request."""
@@ -85,7 +64,6 @@ def test_query_success(transaction_status, mock_http_client):
     assert args[0] == "/mpesa/transactionstatus/v1/query"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
 
-
 def test_query_http_error(transaction_status, mock_http_client):
     """Test handling HTTP errors during transaction status query."""
     request = valid_transaction_status_request()
@@ -93,7 +71,6 @@ def test_query_http_error(transaction_status, mock_http_client):
     with pytest.raises(Exception) as excinfo:
         transaction_status.query(request)
     assert "HTTP error" in str(excinfo.value)
-
 
 def test_transaction_status_response_is_successful_zero_code():
     """Test is_successful method with a zero response code."""
@@ -105,7 +82,6 @@ def test_transaction_status_response_is_successful_zero_code():
     )
     assert resp.is_successful() is True
 
-
 def test_transaction_status_response_is_successful_all_zeros():
     """Test is_successful method with all zeros response code."""
     resp = TransactionStatusResponse(
@@ -115,7 +91,6 @@ def test_transaction_status_response_is_successful_all_zeros():
         ResponseDescription="Accept the service request successfully.",
     )
     assert resp.is_successful() is True
-
 
 def test_transaction_status_response_is_successful_non_zero_code():
     """Test is_successful method with a non-zero response code."""
@@ -127,7 +102,6 @@ def test_transaction_status_response_is_successful_non_zero_code():
     )
     assert resp.is_successful() is False
 
-
 def test_transaction_status_response_is_successful_mixed_code():
     """Test is_successful method with a mixed response code."""
     resp = TransactionStatusResponse(
@@ -138,7 +112,6 @@ def test_transaction_status_response_is_successful_mixed_code():
     )
     assert resp.is_successful() is False
 
-
 def test_transaction_status_response_is_successful_empty_code():
     """Test is_successful method with an empty response code."""
     resp = TransactionStatusResponse(
@@ -148,7 +121,6 @@ def test_transaction_status_response_is_successful_empty_code():
         ResponseDescription="Failed.",
     )
     assert resp.is_successful() is False
-
 
 @pytest.mark.parametrize("invalid_identifier_type", [0, 3, 5, "invalid"])
 def test_transaction_status_request_invalid_identifier_type_raises(
@@ -169,7 +141,6 @@ def test_transaction_status_request_invalid_identifier_type_raises(
     with pytest.raises(ValueError) as excinfo:
         TransactionStatusRequest(**kwargs)
     assert "IdentifierType must be one of" in str(excinfo.value)
-
 
 def test_transaction_status_request_missing_transaction_id_and_originator_conversation_id_raises():
     """Test that missing both TransactionID and OriginalConversationID raises ValueError."""
@@ -192,7 +163,6 @@ def test_transaction_status_request_missing_transaction_id_and_originator_conver
         in str(excinfo.value)
     )
 
-
 def test_transaction_status_request_remarks_too_long_raises():
     """Test that Remarks longer than 100 characters raises ValueError."""
     kwargs = dict(
@@ -209,7 +179,6 @@ def test_transaction_status_request_remarks_too_long_raises():
     with pytest.raises(ValueError) as excinfo:
         TransactionStatusRequest(**kwargs)
     assert "Remarks must not exceed 100 characters." in str(excinfo.value)
-
 
 def test_transaction_status_request_occasion_too_long_raises():
     """Test that Occasion longer than 100 characters raises ValueError."""
@@ -228,7 +197,6 @@ def test_transaction_status_request_occasion_too_long_raises():
     with pytest.raises(ValueError) as excinfo:
         TransactionStatusRequest(**kwargs)
     assert "Occasion must not exceed 100 characters." in str(excinfo.value)
-
 
 def test_transaction_status_request_msisdn_normalization(monkeypatch):
     """Test that PartyA is normalized to a valid Kenyan MSISDN."""
@@ -249,7 +217,6 @@ def test_transaction_status_request_msisdn_normalization(monkeypatch):
     )
     assert req.PartyA == 254712345678
 
-
 def test_transaction_status_request_invalid_msisdn(monkeypatch):
     """Test that invalid PartyA raises ValueError."""
     monkeypatch.setattr("mpesakit.utils.phone.normalize_phone_number", lambda x: None)
@@ -268,11 +235,9 @@ def test_transaction_status_request_invalid_msisdn(monkeypatch):
         TransactionStatusRequest(**kwargs)
     assert "PartyA must be a valid Kenyan MSISDN" in str(excinfo.value)
 
-
 def make_result_parameters(params):
     """Helper function to create ResultParameters from a dictionary."""
     return [TransactionStatusResultParameter(Key=k, Value=v) for k, v in params.items()]
-
 
 def test_result_metadata_properties_all_present():
     """Test that all properties are correctly extracted from ResultParameters."""
@@ -296,7 +261,6 @@ def test_result_metadata_properties_all_present():
     assert meta.transaction_status == "Completed"
     assert meta.transaction_reason == "None"
 
-
 def test_result_metadata_properties_some_missing():
     """Test that properties are correctly extracted when some parameters are missing."""
     params = {
@@ -317,7 +281,6 @@ def test_result_metadata_properties_some_missing():
     assert meta.transaction_status is None
     assert meta.transaction_reason is None
 
-
 def test_result_metadata_properties_none_parameters():
     """Test that properties are None when ResultParameters is empty."""
     meta = TransactionStatusResultMetadata(
@@ -333,7 +296,6 @@ def test_result_metadata_properties_none_parameters():
     assert meta.transaction_receipt is None
     assert meta.transaction_status is None
     assert meta.transaction_reason is None
-
 
 def test_result_callback_schema():
     """Test that TransactionStatusResultCallback schema is correctly defined."""
@@ -356,7 +318,6 @@ def test_result_callback_schema():
     assert callback.Result.transaction_amount == 1000
     assert callback.Result.transaction_receipt == "LKXXXX1234"
     assert callback.Result.transaction_status == "Completed"
-
 
 def test_query_response_code_type_variations(transaction_status, mock_http_client):
     """Ensure TransactionStatusResponse.is_successful handles ResponseCode as str or int without TypeError."""
@@ -383,7 +344,6 @@ def test_query_response_code_type_variations(transaction_status, mock_http_clien
         assert isinstance(resp, TransactionStatusResponse)
         assert resp.is_successful() is expected_success
 
-
 def test_transaction_status_result_callback_is_successful_zero_code():
     """Test is_successful method with ResultCode as '0'."""
     result = TransactionStatusResultMetadata(
@@ -397,7 +357,6 @@ def test_transaction_status_result_callback_is_successful_zero_code():
     )
     callback = TransactionStatusResultCallback(Result=result)
     assert callback.is_successful() is True
-
 
 def test_transaction_status_result_callback_is_successful_all_zeros():
     """Test is_successful method with ResultCode as '00000000'."""
@@ -413,7 +372,6 @@ def test_transaction_status_result_callback_is_successful_all_zeros():
     callback = TransactionStatusResultCallback(Result=result)
     assert callback.is_successful() is True
 
-
 def test_transaction_status_result_callback_is_successful_non_zero_code():
     """Test is_successful method with ResultCode as '1'."""
     result = TransactionStatusResultMetadata(
@@ -427,7 +385,6 @@ def test_transaction_status_result_callback_is_successful_non_zero_code():
     )
     callback = TransactionStatusResultCallback(Result=result)
     assert callback.is_successful() is False
-
 
 def test_transaction_status_result_callback_is_successful_mixed_code():
     """Test is_successful method with ResultCode as '00001'."""
@@ -443,7 +400,6 @@ def test_transaction_status_result_callback_is_successful_mixed_code():
     callback = TransactionStatusResultCallback(Result=result)
     assert callback.is_successful() is False
 
-
 def test_transaction_status_result_callback_is_successful_empty_code():
     """Test is_successful method with an empty ResultCode."""
     result = TransactionStatusResultMetadata(
@@ -457,21 +413,6 @@ def test_transaction_status_result_callback_is_successful_empty_code():
     )
     callback = TransactionStatusResultCallback(Result=result)
     assert callback.is_successful() is False
-
-
-@pytest.fixture
-def mock_async_token_manager():
-    """Mock AsyncTokenManager to return a fixed token."""
-    mock = AsyncMock(spec=AsyncTokenManager)
-    mock.get_token.return_value = "test_token"
-    return mock
-
-
-@pytest.fixture
-def mock_async_http_client():
-    """Mock AsyncHttpClient to simulate async HTTP requests."""
-    return AsyncMock(spec=AsyncHttpClient)
-
 
 @pytest.mark.asyncio
 async def test_async_query_success(mock_async_http_client, mock_async_token_manager):
@@ -503,7 +444,6 @@ async def test_async_query_success(mock_async_http_client, mock_async_token_mana
     args, kwargs = mock_async_http_client.post.call_args
     assert args[0] == "/mpesa/transactionstatus/v1/query"
     assert kwargs["headers"]["Authorization"] == "Bearer test_token"
-
 
 @pytest.mark.asyncio
 async def test_async_query_http_error(mock_async_http_client, mock_async_token_manager):


### PR DESCRIPTION
add test cases and test them . #74 . 
All the test cases have passed.
 The main changes include new fixtures for async mocks, new test cases for async service initialization and querying, and validation of argument filtering in the async query method.

**Async service testing:**

* Added fixtures for `AsyncTokenManager` and `AsyncHttpClient` using `AsyncMock`, and a fixture to create an `AsyncBalanceService` with these dependencies. [[1]](diffhunk://#diff-fb1cc688e907979c92864ae7322b2c16e766c52567907935d8ee16976ae4d611L4-R7) [[2]](diffhunk://#diff-fb1cc688e907979c92864ae7322b2c16e766c52567907935d8ee16976ae4d611R27-R40) [[3]](diffhunk://#diff-fb1cc688e907979c92864ae7322b2c16e766c52567907935d8ee16976ae4d611R50-R58)
* Added tests to verify that `AsyncBalanceService` correctly initializes its `account_balance` attribute and dependencies.

**Async query behavior:**

* Added async test to ensure `AsyncBalanceService.query` returns an `AccountBalanceResponse` and processes a successful response as expected.
* Added async test to verify that unexpected keyword arguments are filtered out in `AsyncBalanceService.query`.