### PR TITLE
Add async support for services tests

### DIFF
--- a/tests/unit/services/test_c2b_service.py
+++ b/tests/unit/services/test_c2b_service.py
@@ -1,8 +1,9 @@
 """Unit tests for the C2BService class in mpesakit.services.c2b module."""
 
 import pytest
-from mpesakit.services.c2b import C2BService
+from mpesakit.services.c2b import C2BService, AsyncC2BService
 from mpesakit.c2b import C2BRegisterUrlResponse, C2BResponseType
+
 
 @pytest.fixture
 def c2b_service(mock_http_client, mock_token_manager):
@@ -11,6 +12,16 @@ def c2b_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_c2b_service(mock_async_http_client, mock_async_token_manager):
+    """Creates an AsyncC2BService instance for testing."""
+    return AsyncC2BService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_register_url_success(c2b_service, mock_http_client):
     """Test successful registration of C2B URLs."""
@@ -31,6 +42,7 @@ def test_register_url_success(c2b_service, mock_http_client):
     assert isinstance(resp, C2BRegisterUrlResponse)
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "URLs registered successfully."
+
 
 def test_register_url_filters_kwargs(c2b_service, mock_http_client):
     """Test that extra kwargs are filtered out in the request."""
@@ -53,6 +65,7 @@ def test_register_url_filters_kwargs(c2b_service, mock_http_client):
     assert resp.ResponseCode == "0"
     assert resp.ResponseDescription == "URLs registered successfully."
 
+
 def test_c2b_service_initializes_correctly(mock_http_client, mock_token_manager):
     """Test C2BService initializes with correct arguments."""
     service = C2BService(
@@ -61,3 +74,64 @@ def test_c2b_service_initializes_correctly(mock_http_client, mock_token_manager)
     )
     assert service.http_client is mock_http_client
     assert service.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_register_url_success(async_c2b_service, mock_async_http_client):
+    """Test successful async registration of C2B URLs."""
+    response_data = {
+        "OriginatorConversationID": "12345",
+        "ConversationID": "AG_20230601_123456789",
+        "ResponseCode": "0",
+        "ResponseDescription": "URLs registered successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_c2b_service.register_url(
+        short_code=600999,
+        response_type=C2BResponseType.COMPLETED,
+        confirmation_url="https://example.com/confirm",
+        validation_url="https://example.com/validate",
+    )
+    assert isinstance(resp, C2BRegisterUrlResponse)
+    assert resp.ResponseCode == "0"
+    assert resp.ResponseDescription == "URLs registered successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_register_url_filters_kwargs(
+    async_c2b_service, mock_async_http_client
+):
+    """Test that async register_url filters out unexpected kwargs."""
+    response_data = {
+        "OriginatorConversationID": "67890",
+        "ConversationID": "AG_20230601_987654321",
+        "ResponseCode": "0",
+        "ResponseDescription": "URLs registered successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_c2b_service.register_url(
+        short_code=600999,
+        response_type=C2BResponseType.COMPLETED,
+        confirmation_url="https://example.com/confirm",
+        validation_url="https://example.com/validate",
+        ExtraField="should_be_filtered",
+    )
+    assert isinstance(resp, C2BRegisterUrlResponse)
+    assert resp.ResponseCode == "0"
+    assert resp.ResponseDescription == "URLs registered successfully."
+
+
+def test_async_c2b_service_initializes_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncC2BService initializes with correct arguments."""
+    service = AsyncC2BService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.c2b.http_client is mock_async_http_client
+    assert service.c2b.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_dynamic_qr_service.py
+++ b/tests/unit/services/test_dynamic_qr_service.py
@@ -1,11 +1,15 @@
 """Unit tests for the DynamicQRCodeService class in mpesakit.services.dynamic_qr module."""
 
 import pytest
-from mpesakit.services.dynamic_qr import DynamicQRCodeService
+from mpesakit.services.dynamic_qr import (
+    DynamicQRCodeService,
+    AsyncDynamicQRCodeService,
+)
 from mpesakit.dynamic_qr_code import (
     DynamicQRGenerateResponse,
     DynamicQRTransactionType,
 )
+
 
 @pytest.fixture
 def dynamic_qr_service(mock_http_client, mock_token_manager):
@@ -14,6 +18,16 @@ def dynamic_qr_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_dynamic_qr_service(mock_async_http_client, mock_async_token_manager):
+    """Creates an AsyncDynamicQRCodeService instance for testing."""
+    return AsyncDynamicQRCodeService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_generate_success(dynamic_qr_service, mock_http_client):
     """Test successful generation of a dynamic QR code."""
@@ -36,6 +50,7 @@ def test_generate_success(dynamic_qr_service, mock_http_client):
     )
     assert isinstance(resp, DynamicQRGenerateResponse)
     assert resp.is_successful() is True
+
 
 def test_generate_filters_kwargs(dynamic_qr_service, mock_http_client):
     """Test that extra kwargs are filtered out in the request."""
@@ -64,6 +79,7 @@ def test_generate_filters_kwargs(dynamic_qr_service, mock_http_client):
     assert isinstance(resp, DynamicQRGenerateResponse)
     assert resp.is_successful() is True
 
+
 def test_dynamic_qr_service_initializes_correctly(mock_http_client, mock_token_manager):
     """Test DynamicQRCodeService initializes with correct arguments."""
     service = DynamicQRCodeService(
@@ -72,3 +88,73 @@ def test_dynamic_qr_service_initializes_correctly(mock_http_client, mock_token_m
     )
     assert service.http_client is mock_http_client
     assert service.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_generate_success(
+    async_dynamic_qr_service, mock_async_http_client
+):
+    """Test successful async generation of a dynamic QR code."""
+    response_data = {
+        "ResponseCode": "00",
+        "RequestID": "16738-27456357-1",
+        "ResponseDescription": "QR Code Successfully Generated.",
+        "QRCode": "iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAIAAAD2HxkiAAAHtElEQVR42...",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_dynamic_qr_service.generate(
+        merchant_name="Test Merchant",
+        ref_no="REF123",
+        amount=100.0,
+        trx_code=DynamicQRTransactionType.BUY_GOODS,
+        cpi="CPI123",
+        size="300",
+    )
+    assert isinstance(resp, DynamicQRGenerateResponse)
+    assert resp.is_successful() is True
+
+
+@pytest.mark.asyncio
+async def test_async_generate_filters_kwargs(
+    async_dynamic_qr_service, mock_async_http_client
+):
+    """Test that async generate filters out unexpected kwargs."""
+    response_data = {
+        "QRCode": "base64string",
+        "MerchantName": "Test Merchant",
+        "RefNo": "REF456",
+        "Amount": 200.0,
+        "TrxCode": DynamicQRTransactionType.BUY_GOODS.value,
+        "CPI": "CPI456",
+        "Size": "400x400",
+        "ResponseCode": "0",
+        "ResponseDescription": "QR code generated successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_dynamic_qr_service.generate(
+        merchant_name="Test Merchant",
+        ref_no="REF456",
+        amount=200.0,
+        trx_code=DynamicQRTransactionType.BUY_GOODS.value,
+        cpi="CPI456",
+        size="400x400",
+        ExtraField="should_be_filtered",
+    )
+    assert isinstance(resp, DynamicQRGenerateResponse)
+    assert resp.is_successful() is True
+
+
+def test_async_dynamic_qr_service_initializes_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncDynamicQRCodeService initializes with correct arguments."""
+    service = AsyncDynamicQRCodeService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.qr_code.http_client is mock_async_http_client
+    assert service.qr_code.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_express_service.py
+++ b/tests/unit/services/test_express_service.py
@@ -1,7 +1,7 @@
 """Unit tests for the StkPushService facade in mpesakit.services.express module."""
 
 import pytest
-from mpesakit.services.express import StkPushService
+from mpesakit.services.express import StkPushService, AsyncStkPushService
 
 from mpesakit.mpesa_express import (
     StkPushSimulateResponse,
@@ -9,15 +9,25 @@ from mpesakit.mpesa_express import (
     TransactionType,
 )
 
+
 @pytest.fixture
 def stk_push_service(mock_http_client, mock_token_manager):
     """Creates a StkPushService instance for testing."""
-    # Patch StkPush inside the service to use a mock
     service = StkPushService(
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
     return service
+
+
+@pytest.fixture
+def async_stk_push_service(mock_async_http_client, mock_async_token_manager):
+    """Creates an AsyncStkPushService instance for testing."""
+    return AsyncStkPushService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_push_success(stk_push_service, mock_http_client):
     """Test successful STK Push transaction."""
@@ -45,6 +55,7 @@ def test_push_success(stk_push_service, mock_http_client):
 
     assert isinstance(resp, StkPushSimulateResponse)
     assert resp.is_successful() is True
+
 
 def test_push_filters_kwargs(stk_push_service, mock_http_client):
     """Test that extra kwargs are filtered out in push."""
@@ -74,6 +85,7 @@ def test_push_filters_kwargs(stk_push_service, mock_http_client):
     assert isinstance(resp, StkPushSimulateResponse)
     assert not hasattr(resp, "ExtraField")
 
+
 def test_query_success(stk_push_service, mock_http_client):
     """Test successful STK Push query."""
     response = {
@@ -93,6 +105,7 @@ def test_query_success(stk_push_service, mock_http_client):
     )
     assert isinstance(resp, StkPushQueryResponse)
     assert resp.is_successful() is True
+
 
 def test_query_filters_kwargs(stk_push_service, mock_http_client):
     """Test that extra kwargs are filtered out in query."""
@@ -116,6 +129,7 @@ def test_query_filters_kwargs(stk_push_service, mock_http_client):
     resp.is_successful() is True
     assert not hasattr(resp, "ExtraField")
 
+
 def test_stk_push_service_initializes_stk_push_correctly(
     mock_http_client, mock_token_manager
 ):
@@ -128,3 +142,125 @@ def test_stk_push_service_initializes_stk_push_correctly(
     assert service.token_manager is mock_token_manager
     assert service.stk_push.http_client is mock_http_client
     assert service.stk_push.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_push_success(async_stk_push_service, mock_async_http_client):
+    """Test successful async STK Push transaction."""
+    response = {
+        "MerchantRequestID": "16813-1590513-1",
+        "CheckoutRequestID": "ws_CO_DMZ_123212312_2342347678234",
+        "ResponseCode": 0,
+        "ResponseDescription": "Accepted",
+        "CustomerMessage": "Success. Request accepted for processing.",
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_stk_push_service.push(
+        business_short_code=654321,
+        passkey="testpasskey",
+        transaction_type=TransactionType.CUSTOMER_PAYBILL_ONLINE.value,
+        amount=10,
+        party_a="254712345678",
+        party_b="654321",
+        phone_number="254712345678",
+        callback_url="https://example.com/callback",
+        account_reference="Test",
+        transaction_desc="Payment",
+    )
+
+    assert isinstance(resp, StkPushSimulateResponse)
+    assert resp.is_successful() is True
+
+
+@pytest.mark.asyncio
+async def test_async_push_filters_kwargs(
+    async_stk_push_service, mock_async_http_client
+):
+    """Test that async push filters out unexpected kwargs."""
+    response = {
+        "MerchantRequestID": "16813-1590513-1",
+        "CheckoutRequestID": "ws_CO_DMZ_123212312_2342347678234",
+        "ResponseCode": 0,
+        "ResponseDescription": "Accepted",
+        "CustomerMessage": "Success. Request accepted for processing.",
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_stk_push_service.push(
+        business_short_code=654321,
+        passkey="testpasskey",
+        transaction_type=TransactionType.CUSTOMER_PAYBILL_ONLINE.value,
+        amount=10,
+        party_a="254712345678",
+        party_b="654321",
+        phone_number="254712345678",
+        callback_url="https://example.com/callback",
+        account_reference="Test",
+        transaction_desc="Payment",
+        ExtraField="should_be_filtered",
+    )
+    assert isinstance(resp, StkPushSimulateResponse)
+    assert not hasattr(resp, "ExtraField")
+
+
+@pytest.mark.asyncio
+async def test_async_query_success(async_stk_push_service, mock_async_http_client):
+    """Test successful async STK Push query."""
+    response = {
+        "MerchantRequestID": "22205-34066-1",
+        "CheckoutRequestID": "ws_CO_13012021093521236557",
+        "ResponseCode": 0,
+        "ResponseDescription": "Accepted",
+        "ResultCode": 0,
+        "ResultDesc": "Processed successfully.",
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_stk_push_service.query(
+        business_short_code=654321,
+        passkey="testpasskey",
+        checkout_request_id="ws_CO_13012021093521236557",
+    )
+    assert isinstance(resp, StkPushQueryResponse)
+    assert resp.is_successful() is True
+
+
+@pytest.mark.asyncio
+async def test_async_query_filters_kwargs(
+    async_stk_push_service, mock_async_http_client
+):
+    """Test that async query filters out unexpected kwargs."""
+    response = {
+        "MerchantRequestID": "22205-34066-1",
+        "CheckoutRequestID": "ws_CO_13012021093521236557",
+        "ResponseCode": 0,
+        "ResponseDescription": "Accepted",
+        "ResultCode": 0,
+        "ResultDesc": "Processed successfully.",
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_stk_push_service.query(
+        business_short_code=654321,
+        passkey="testpasskey",
+        checkout_request_id="ws_CO_13012021093521236557",
+        ExtraField="should_be_filtered",
+    )
+    assert isinstance(resp, StkPushQueryResponse)
+    assert resp.is_successful() is True
+    assert not hasattr(resp, "ExtraField")
+
+
+def test_async_stk_push_service_initializes_stk_push_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncStkPushService initializes with correct arguments."""
+    service = AsyncStkPushService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.stk_push.http_client is mock_async_http_client
+    assert service.stk_push.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_ratiba_service.py
+++ b/tests/unit/services/test_ratiba_service.py
@@ -1,13 +1,14 @@
 """Unit tests for the RatibaService facade in mpesakit.services.ratiba module."""
 
 import pytest
-from mpesakit.services.ratiba import RatibaService
+from mpesakit.services.ratiba import RatibaService, AsyncRatibaService
 from mpesakit.mpesa_ratiba import (
     StandingOrderResponse,
     TransactionTypeEnum,
     ReceiverPartyIdentifierTypeEnum,
     FrequencyEnum,
 )
+
 
 @pytest.fixture
 def ratiba_service(mock_http_client, mock_token_manager):
@@ -16,6 +17,16 @@ def ratiba_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_ratiba_service(mock_async_http_client, mock_async_token_manager):
+    """Creates an AsyncRatibaService instance for testing."""
+    return AsyncRatibaService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_create_standing_order_success(ratiba_service, mock_http_client):
     """Test successful Standing Order creation."""
@@ -50,6 +61,7 @@ def test_create_standing_order_success(ratiba_service, mock_http_client):
 
     assert isinstance(resp, StandingOrderResponse)
     assert resp.is_successful() is True
+
 
 def test_create_standing_order_filters_kwargs(ratiba_service, mock_http_client):
     """Test that extra kwargs are filtered out in create_standing_order."""
@@ -87,6 +99,7 @@ def test_create_standing_order_filters_kwargs(ratiba_service, mock_http_client):
     assert resp.is_successful() is True
     assert not hasattr(resp, "ExtraField")
 
+
 def test_ratiba_service_initializes_ratiba_correctly(
     mock_http_client, mock_token_manager
 ):
@@ -99,3 +112,95 @@ def test_ratiba_service_initializes_ratiba_correctly(
     assert service.token_manager is mock_token_manager
     assert service.ratiba.http_client is mock_http_client
     assert service.ratiba.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_create_standing_order_success(
+    async_ratiba_service, mock_async_http_client
+):
+    """Test successful async Standing Order creation."""
+    response = {
+        "ResponseHeader": {
+            "responseRefID": "4dd9b5d9-d738-42ba-9326-2cc99e966000",
+            "responseCode": "200",
+            "responseDescription": "Request accepted for processing",
+            "ResultDesc": "The service request is processed successfully.",
+        },
+        "ResponseBody": {
+            "responseDescription": "Request accepted for processing",
+            "responseCode": "200",
+        },
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_ratiba_service.create_standing_order(
+        standing_order_name="MyOrder",
+        start_date="20240601",
+        end_date="20241201",
+        business_short_code="123456",
+        transaction_type=TransactionTypeEnum.STANDING_ORDER_CUSTOMER_PAY_BILL,
+        receiver_party_identifier_type=ReceiverPartyIdentifierTypeEnum.BUSINESS_SHORT_CODE,
+        amount="1000",
+        party_a="254712345678",
+        callback_url="https://example.com/callback",
+        account_reference="Ref123",
+        transaction_desc="Monthly Pay",
+        frequency=FrequencyEnum.MONTHLY,
+    )
+
+    assert isinstance(resp, StandingOrderResponse)
+    assert resp.is_successful() is True
+
+
+@pytest.mark.asyncio
+async def test_async_create_standing_order_filters_kwargs(
+    async_ratiba_service, mock_async_http_client
+):
+    """Test that async create_standing_order filters out unexpected kwargs."""
+    response = {
+        "ResponseHeader": {
+            "responseRefID": "4dd9b5d9-d738-42ba-9326-2cc99e966000",
+            "responseCode": "200",
+            "responseDescription": "Request accepted for processing",
+            "ResultDesc": "The service request is processed successfully.",
+        },
+        "ResponseBody": {
+            "responseDescription": "Request accepted for processing",
+            "responseCode": "200",
+        },
+    }
+    mock_async_http_client.post.return_value = response
+
+    resp = await async_ratiba_service.create_standing_order(
+        standing_order_name="Order2",
+        start_date="20240601",
+        end_date="20241201",
+        business_short_code="654321",
+        transaction_type=TransactionTypeEnum.STANDING_ORDER_CUSTOMER_PAY_BILL,
+        receiver_party_identifier_type=ReceiverPartyIdentifierTypeEnum.BUSINESS_SHORT_CODE,
+        amount="500",
+        party_a="254798765432",
+        callback_url="https://example.com/callback2",
+        account_reference="Ref456",
+        transaction_desc="Weekly pay",
+        frequency=FrequencyEnum.WEEKLY,
+        ExtraField="should_be_filtered",
+    )
+
+    assert isinstance(resp, StandingOrderResponse)
+    assert resp.is_successful() is True
+    assert not hasattr(resp, "ExtraField")
+
+
+def test_async_ratiba_service_initializes_ratiba_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncRatibaService initializes with correct arguments."""
+    service = AsyncRatibaService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.ratiba.http_client is mock_async_http_client
+    assert service.ratiba.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_reversal_service.py
+++ b/tests/unit/services/test_reversal_service.py
@@ -1,8 +1,9 @@
 """Unit tests for ReversalService class."""
 
 import pytest
-from mpesakit.services.reversal import ReversalService
+from mpesakit.services.reversal import ReversalService, AsyncReversalService
 from mpesakit.reversal import ReversalResponse
+
 
 @pytest.fixture
 def reversal_service(mock_http_client, mock_token_manager):
@@ -11,6 +12,16 @@ def reversal_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_reversal_service(mock_async_http_client, mock_async_token_manager):
+    """Fixture to create an AsyncReversalService instance with mocked dependencies."""
+    return AsyncReversalService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_reverse_calls_reversal(reversal_service, mock_http_client):
     """Test that reverse calls the Reversal.reverse method with correct request."""
@@ -36,6 +47,7 @@ def test_reverse_calls_reversal(reversal_service, mock_http_client):
     assert isinstance(resp, ReversalResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
+
 
 def test_reverse_filters_kwargs(reversal_service, mock_http_client):
     """Test that reverse filters out unexpected kwargs."""
@@ -65,6 +77,7 @@ def test_reverse_filters_kwargs(reversal_service, mock_http_client):
     # unexpected_field should not be present
     assert not hasattr(resp, "unexpected_field")
 
+
 def test_reversal_service_initializes_reversal_correctly(
     mock_http_client, mock_token_manager
 ):
@@ -79,3 +92,76 @@ def test_reversal_service_initializes_reversal_correctly(
     if hasattr(service, "reversal"):
         assert service.reversal.http_client is mock_http_client
         assert service.reversal.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_reverse_calls_reversal(
+    async_reversal_service, mock_async_http_client
+):
+    """Test that async reverse calls AsyncReversal.reverse."""
+    response_data = {
+        "OriginatorConversationID": "71840-27539181-07",
+        "ConversationID": "AG_20210709_12346c8e6f8858d7b70a",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_reversal_service.reverse(
+        initiator="TestInit610",
+        security_credential="encrypted_credential",
+        transaction_id="LKXXXX1234",
+        amount=100,
+        receiver_party=600610,
+        result_url="https://ip:port/result",
+        queue_timeout_url="https://ip:port/timeout",
+        remarks="Test",
+        occasion="work",
+    )
+    assert isinstance(resp, ReversalResponse)
+    assert resp.is_successful() is True
+    assert resp.ResponseDescription == "Accept the service request successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_reverse_filters_kwargs(
+    async_reversal_service, mock_async_http_client
+):
+    """Test that async reverse filters out unexpected kwargs."""
+    response_data = {
+        "OriginatorConversationID": "71840-27539181-07",
+        "ConversationID": "AG_20210709_12346c8e6f8858d7b70a",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_reversal_service.reverse(
+        initiator="TestInit610",
+        security_credential="encrypted_credential",
+        transaction_id="LKXXXX1234",
+        amount=100,
+        receiver_party=600610,
+        result_url="https://ip:port/result",
+        queue_timeout_url="https://ip:port/timeout",
+        remarks="Test",
+        occasion="work",
+        unexpected_field="should be ignored",
+    )
+    assert isinstance(resp, ReversalResponse)
+    assert resp.is_successful() is True
+    assert not hasattr(resp, "unexpected_field")
+
+
+def test_async_reversal_service_initializes_reversal_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncReversalService initializes with correct arguments."""
+    service = AsyncReversalService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service._reversal.http_client is mock_async_http_client
+    assert service._reversal.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_tax_service.py
+++ b/tests/unit/services/test_tax_service.py
@@ -1,8 +1,9 @@
 """Unit tests for TaxService class."""
 
 import pytest
-from mpesakit.services.tax import TaxService
+from mpesakit.services.tax import TaxService, AsyncTaxService
 from mpesakit.tax_remittance import TaxRemittanceResponse
+
 
 @pytest.fixture
 def tax_service(mock_http_client, mock_token_manager):
@@ -11,6 +12,16 @@ def tax_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_tax_service(mock_async_http_client, mock_async_token_manager):
+    """Fixture to create an AsyncTaxService instance with mocked dependencies."""
+    return AsyncTaxService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_remittance_calls_tax_remittance(tax_service, mock_http_client):
     """Test that remittance calls TaxRemittance.remittance with correct request."""
@@ -35,6 +46,7 @@ def test_remittance_calls_tax_remittance(tax_service, mock_http_client):
     assert isinstance(resp, TaxRemittanceResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
+
 
 def test_remittance_filters_kwargs(tax_service, mock_http_client):
     """Test that remittance filters out unexpected kwargs."""
@@ -62,6 +74,7 @@ def test_remittance_filters_kwargs(tax_service, mock_http_client):
     # unexpected_field should not be present in the response
     assert not hasattr(resp, "unexpected_field")
 
+
 def test_tax_service_initializes_tax_correctly(mock_http_client, mock_token_manager):
     """Test TaxService initializes with correct http_client and token_manager."""
     service = TaxService(
@@ -74,3 +87,74 @@ def test_tax_service_initializes_tax_correctly(mock_http_client, mock_token_mana
     if hasattr(service, "tax"):
         assert service.tax.http_client is mock_http_client
         assert service.tax.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_remittance_calls_tax_remittance(
+    async_tax_service, mock_async_http_client
+):
+    """Test that async remittance calls AsyncTaxRemittance.remittance."""
+    response_data = {
+        "OriginatorConversationID": "5118-111210482-1",
+        "ConversationID": "AG_20230420_2010759fd5662ef6d054",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_tax_service.remittance(
+        initiator="TaxPayer",
+        security_credential="encrypted_credential",
+        amount=239,
+        party_a=888880,
+        remarks="OK",
+        account_reference="353353",
+        result_url="https://mydomain.com/b2b/remittax/result/",
+        queue_timeout_url="https://mydomain.com/b2b/remittax/queue/",
+    )
+    assert isinstance(resp, TaxRemittanceResponse)
+    assert resp.is_successful() is True
+    assert resp.ResponseDescription == "Accept the service request successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_remittance_filters_kwargs(
+    async_tax_service, mock_async_http_client
+):
+    """Test that async remittance filters out unexpected kwargs."""
+    response_data = {
+        "OriginatorConversationID": "5118-111210482-1",
+        "ConversationID": "AG_20230420_2010759fd5662ef6d054",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_tax_service.remittance(
+        initiator="TaxPayer",
+        security_credential="encrypted_credential",
+        amount=239,
+        party_a=888880,
+        remarks="OK",
+        account_reference="353353",
+        result_url="https://mydomain.com/b2b/remittax/result/",
+        queue_timeout_url="https://mydomain.com/b2b/remittax/queue/",
+        unexpected_field="should be ignored",
+    )
+    assert isinstance(resp, TaxRemittanceResponse)
+    assert resp.is_successful() is True
+    assert not hasattr(resp, "unexpected_field")
+
+
+def test_async_tax_service_initializes_tax_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncTaxService initializes with correct arguments."""
+    service = AsyncTaxService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.tax_remittance.http_client is mock_async_http_client
+    assert service.tax_remittance.token_manager is mock_async_token_manager

--- a/tests/unit/services/test_transaction_service.py
+++ b/tests/unit/services/test_transaction_service.py
@@ -1,8 +1,12 @@
 """Unit tests for TransactionService class."""
 
 import pytest
-from mpesakit.services.transaction import TransactionService
+from mpesakit.services.transaction import (
+    TransactionService,
+    AsyncTransactionService,
+)
 from mpesakit.transaction_status import TransactionStatusResponse
+
 
 @pytest.fixture
 def transaction_service(mock_http_client, mock_token_manager):
@@ -11,6 +15,16 @@ def transaction_service(mock_http_client, mock_token_manager):
         http_client=mock_http_client,
         token_manager=mock_token_manager,
     )
+
+
+@pytest.fixture
+def async_transaction_service(mock_async_http_client, mock_async_token_manager):
+    """Fixture to create an AsyncTransactionService instance with mocked dependencies."""
+    return AsyncTransactionService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+
 
 def test_query_status_calls_transaction_status(transaction_service, mock_http_client):
     """Test that query_status calls TransactionStatus.query with correct request."""
@@ -37,6 +51,7 @@ def test_query_status_calls_transaction_status(transaction_service, mock_http_cl
     assert isinstance(resp, TransactionStatusResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
+
 
 def test_query_status_default_command_id(transaction_service, mock_http_client):
     """Test that query_status calls TransactionStatus.query with correct request."""
@@ -66,6 +81,7 @@ def test_query_status_default_command_id(transaction_service, mock_http_client):
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
 
+
 def test_query_status_default_remarks(transaction_service, mock_http_client):
     """Test that query_status calls TransactionStatus.query with correct request."""
     response_data = {
@@ -93,6 +109,7 @@ def test_query_status_default_remarks(transaction_service, mock_http_client):
     assert isinstance(resp, TransactionStatusResponse)
     assert resp.is_successful() is True
     assert resp.ResponseDescription == "Accept the service request successfully."
+
 
 def test_query_status_filters_kwargs(transaction_service, mock_http_client):
     """Test that query_status filters out unexpected kwargs."""
@@ -122,6 +139,7 @@ def test_query_status_filters_kwargs(transaction_service, mock_http_client):
     # unexpected_field should not be present in the response
     assert not hasattr(resp, "unexpected_field")
 
+
 def test_transaction_service_initializes_correctly(
     mock_http_client, mock_token_manager
 ):
@@ -132,3 +150,138 @@ def test_transaction_service_initializes_correctly(
     )
     assert service.http_client is mock_http_client
     assert service.token_manager is mock_token_manager
+
+
+@pytest.mark.asyncio
+async def test_async_query_status_calls_transaction_status(
+    async_transaction_service, mock_async_http_client
+):
+    """Test that async query_status calls AsyncTransactionStatus.query."""
+    response_data = {
+        "ConversationID": "AG_20170717_00006c6f7f5b8b6b1a62",
+        "OriginatorConversationID": "12345-67890-1",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_transaction_service.query_status(
+        initiator="testapi",
+        security_credential="encrypted_credential",
+        command_id="TransactionStatusQuery",
+        transaction_id="LKXXXX1234",
+        party_a=600999,
+        identifier_type=4,
+        result_url="https://example.com/result",
+        queue_timeout_url="https://example.com/timeout",
+        remarks="Status check for transaction",
+        occasion="JuneSalary",
+    )
+    assert isinstance(resp, TransactionStatusResponse)
+    assert resp.is_successful() is True
+    assert resp.ResponseDescription == "Accept the service request successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_query_status_default_command_id(
+    async_transaction_service, mock_async_http_client
+):
+    """Test that async query_status uses the default CommandID when omitted."""
+    response_data = {
+        "ConversationID": "AG_20170717_00006c6f7f5b8b6b1a62",
+        "OriginatorConversationID": "12345-67890-1",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_transaction_service.query_status(
+        initiator="testapi",
+        security_credential="encrypted_credential",
+        transaction_id="LKXXXX1234",
+        party_a=600999,
+        identifier_type=4,
+        result_url="https://example.com/result",
+        queue_timeout_url="https://example.com/timeout",
+        remarks="Status check for transaction",
+        occasion="JuneSalary",
+    )
+
+    assert isinstance(resp, TransactionStatusResponse)
+    assert resp.is_successful() is True
+    assert resp.ResponseDescription == "Accept the service request successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_query_status_default_remarks(
+    async_transaction_service, mock_async_http_client
+):
+    """Test that async query_status uses the default Remarks when omitted."""
+    response_data = {
+        "ConversationID": "AG_20170717_00006c6f7f5b8b6b1a62",
+        "OriginatorConversationID": "12345-67890-1",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_transaction_service.query_status(
+        initiator="testapi",
+        security_credential="encrypted_credential",
+        command_id="TransactionStatusQuery",
+        transaction_id="LKXXXX1234",
+        party_a=600999,
+        identifier_type=4,
+        result_url="https://example.com/result",
+        queue_timeout_url="https://example.com/timeout",
+        occasion="JuneSalary",
+    )
+
+    assert isinstance(resp, TransactionStatusResponse)
+    assert resp.is_successful() is True
+    assert resp.ResponseDescription == "Accept the service request successfully."
+
+
+@pytest.mark.asyncio
+async def test_async_query_status_filters_kwargs(
+    async_transaction_service, mock_async_http_client
+):
+    """Test that async query_status filters out unexpected kwargs."""
+    response_data = {
+        "ConversationID": "AG_20170717_00006c6f7f5b8b6b1a62",
+        "OriginatorConversationID": "12345-67890-1",
+        "ResponseCode": "0",
+        "ResponseDescription": "Accept the service request successfully.",
+    }
+    mock_async_http_client.post.return_value = response_data
+
+    resp = await async_transaction_service.query_status(
+        initiator="testapi",
+        security_credential="encrypted_credential",
+        command_id="TransactionStatusQuery",
+        transaction_id="LKXXXX1234",
+        party_a=600999,
+        identifier_type=4,
+        result_url="https://example.com/result",
+        queue_timeout_url="https://example.com/timeout",
+        remarks="Status check for transaction",
+        occasion="JuneSalary",
+        unexpected_field="should be ignored",
+    )
+    assert isinstance(resp, TransactionStatusResponse)
+    assert resp.is_successful() is True
+    assert not hasattr(resp, "unexpected_field")
+
+
+def test_async_transaction_service_initializes_correctly(
+    mock_async_http_client, mock_async_token_manager
+):
+    """Test AsyncTransactionService initializes with correct arguments."""
+    service = AsyncTransactionService(
+        http_client=mock_async_http_client,
+        token_manager=mock_async_token_manager,
+    )
+    assert service.http_client is mock_async_http_client
+    assert service.token_manager is mock_async_token_manager
+    assert service.transaction_status.http_client is mock_async_http_client
+    assert service.transaction_status.token_manager is mock_async_token_manager


### PR DESCRIPTION
Enhanced unit tests for multiple services including C2B, Dynamic QR, Express, Ratiba, Reversal, Tax, and Transaction by introducing async counterparts. Added fixtures for Async services and implemented async test cases to ensure proper functionality and handling of unexpected kwargs. This improves test coverage and maintains consistency across the testing framework.
 the test are for the following issues :
 #76 
#77 
#71 
#78 
#79 
#80 
#81 